### PR TITLE
GC control functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,20 +36,25 @@ print(result)
 <p align="center">Factorial benchmark</p>
 
 ```
-> hyperfine --warmup 5 'target/release/mica code/functions.mi' 'lua5.1 code/functions.lua'
+> hyperfine --warmup 5 'target/release/mica code/functions.mi' 'lua5.1 code/functions.lua' 'python3 code/functions.py'
 Benchmark 1: target/release/mica code/functions.mi
-  Time (mean ± σ):      93.2 ms ±   0.6 ms    [User: 92.1 ms, System: 1.2 ms]
-  Range (min … max):    92.0 ms …  95.5 ms    31 runs
+  Time (mean ± σ):      94.8 ms ±   6.8 ms    [User: 93.8 ms, System: 1.2 ms]
+  Range (min … max):    91.5 ms … 121.1 ms    31 runs
 
 Benchmark 2: lua5.1 code/functions.lua
-  Time (mean ± σ):      27.4 ms ±   0.2 ms    [User: 26.1 ms, System: 1.5 ms]
-  Range (min … max):    27.0 ms …  28.5 ms    98 runs
+  Time (mean ± σ):      27.5 ms ±   1.9 ms    [User: 26.7 ms, System: 1.2 ms]
+  Range (min … max):    26.9 ms …  45.9 ms    97 runs
+
+Benchmark 3: python3 code/functions.py
+  Time (mean ± σ):     117.5 ms ±   1.3 ms    [User: 116.2 ms, System: 1.4 ms]
+  Range (min … max):   115.6 ms … 119.9 ms    25 runs
 
 Summary
   'lua5.1 code/functions.lua' ran
-    3.40 ± 0.04 times faster than 'target/release/mica code/functions.mi'
+    3.44 ± 0.34 times faster than 'target/release/mica code/functions.mi'
+    4.27 ± 0.30 times faster than 'python3 code/functions.py'
 ```
 It's not ideal yet but hopefully it'll get better with time. Current bottlenecks include:
-- A really stupid compiler that does zero optimizations
 - Stack-based rather than register-based virtual machine
-- Rust's safety features working against my goal of being faster than Lua
+- Rust not having a way of doing direct threading in the interpreter dispatch loop. _Tail calls when_
+- The bytecode compiler not optimizing much

--- a/mica-hl/src/engine.rs
+++ b/mica-hl/src/engine.rs
@@ -18,7 +18,10 @@ use crate::{
    TypeBuilder, UserData, Value,
 };
 
+/// The implementation of a raw foreign function.
 pub use mica_language::bytecode::ForeignFunction as RawForeignFunction;
+/// The kind of a raw function.
+pub use mica_language::bytecode::FunctionKind as RawFunctionKind;
 
 /// Options for debugging the language implementation.
 #[derive(Debug, Clone, Copy, Default)]
@@ -214,7 +217,7 @@ impl Engine {
       &mut self,
       name: &str,
       parameter_count: impl Into<Option<u16>>,
-      f: RawForeignFunction,
+      f: FunctionKind,
    ) -> Result<(), Error> {
       let global_id = name.to_global_id(&mut self.env)?;
       let function_id = self
@@ -222,7 +225,7 @@ impl Engine {
          .create_function(Function {
             name: Rc::from(name),
             parameter_count: parameter_count.into(), // doesn't matter for non-methods
-            kind: FunctionKind::Foreign(f),
+            kind: f,
          })
          .map_err(|_| Error::TooManyFunctions)?;
       let function = RawValue::from(self.gc.allocate(Closure {
@@ -242,7 +245,11 @@ impl Engine {
       V: ffvariants::Bare,
       F: ForeignFunction<V>,
    {
-      self.add_raw_function(name, F::parameter_count(), f.into_raw_foreign_function())
+      self.add_raw_function(
+         name,
+         F::parameter_count(),
+         FunctionKind::Foreign(f.into_raw_foreign_function()),
+      )
    }
 
    /// Declares a type in the global scope.

--- a/mica-hl/src/function.rs
+++ b/mica-hl/src/function.rs
@@ -18,7 +18,7 @@ pub struct Arguments<'a> {
 }
 
 impl<'a> Arguments<'a> {
-   fn new(raw_arguments: &'a [RawValue]) -> Self {
+   pub fn new(raw_arguments: &'a [RawValue]) -> Self {
       // Skip the first argument, which is `self` (or the currently called function).
       Self {
          this: raw_arguments[0],

--- a/mica-language/src/bytecode.rs
+++ b/mica-language/src/bytecode.rs
@@ -509,6 +509,12 @@ pub enum CaptureKind {
 /// The ABI of a raw foreign function.
 pub type ForeignFunction = Box<dyn FnMut(&mut Memory, &[RawValue]) -> Result<RawValue, ErrorKind>>;
 
+/// The kind of a controlling function.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Control {
+   GcCollect,
+}
+
 /// The kind of the function (bytecode or FFI).
 pub enum FunctionKind {
    Bytecode {
@@ -516,6 +522,7 @@ pub enum FunctionKind {
       captured_locals: Vec<CaptureKind>,
    },
    Foreign(ForeignFunction),
+   Control(Control),
 }
 
 impl std::fmt::Debug for FunctionKind {
@@ -530,6 +537,7 @@ impl std::fmt::Debug for FunctionKind {
             .field("captured_locals", captured_locals)
             .finish(),
          Self::Foreign(..) => f.debug_struct("Foreign").finish_non_exhaustive(),
+         Self::Control(ctl) => f.debug_tuple("Control").field(ctl).finish(),
       }
    }
 }

--- a/mica-language/src/gc.rs
+++ b/mica-language/src/gc.rs
@@ -203,7 +203,18 @@ impl Memory {
    /// Automatic collections only trigger upon specific conditions, such as a specific amount of
    /// generations passing. Though right now there are no such conditions.
    pub(crate) unsafe fn auto_collect(&mut self, roots: impl Iterator<Item = RawValue>) {
+      #[cfg(feature = "trace-gc")]
+      {
+         println!(
+            "gc | auto_collect called with strategy {:?}",
+            self.auto_strategy
+         );
+      }
       if self.auto_strategy.satisfied(self) {
+         #[cfg(feature = "trace-gc")]
+         {
+            println!("gc | strategy satisfied, collecting",);
+         }
          self.collect(roots);
          self.auto_strategy = self.auto_strategy.update(self);
       }

--- a/mica-std/src/core.rs
+++ b/mica-std/src/core.rs
@@ -5,6 +5,8 @@ use std::fmt::Write;
 
 use mica_hl::{Arguments, Engine, MicaResultExt, Value};
 
+use crate::gc::load_gc;
+
 fn print(arguments: Arguments) {
    for value in arguments.array() {
       print!("{value}");
@@ -57,6 +59,8 @@ pub fn load_core(engine: &mut Engine) -> Result<(), mica_hl::Error> {
    engine.add_function("debug", debug)?;
    engine.add_function("error", error)?;
    engine.add_function("assert", assert)?;
+
+   load_gc(engine)?;
 
    Ok(())
 }

--- a/mica-std/src/gc.rs
+++ b/mica-std/src/gc.rs
@@ -1,0 +1,58 @@
+//! The `Gc` type.
+
+use mica_hl::language::bytecode::Control;
+use mica_hl::language::gc::AutoStrategy;
+use mica_hl::{Arguments, Engine, RawFunctionKind, RawValue, TypeBuilder, UserData};
+
+struct GcType;
+
+impl UserData for GcType {}
+
+pub(crate) fn load_gc(engine: &mut Engine) -> Result<(), mica_hl::Error> {
+   engine.add_type(
+      TypeBuilder::<GcType>::new("Gc")
+         .add_raw_static(
+            "disable",
+            Some(1),
+            RawFunctionKind::Foreign(Box::new(|gc, _| {
+               gc.auto_strategy = AutoStrategy::Disabled;
+               Ok(RawValue::from(()))
+            })),
+         )
+         .add_raw_static(
+            "enable_always_run",
+            Some(1),
+            RawFunctionKind::Foreign(Box::new(|gc, _| {
+               gc.auto_strategy = AutoStrategy::AlwaysRun;
+               Ok(RawValue::from(()))
+            })),
+         )
+         .add_raw_static(
+            "enable_with_ceiling",
+            Some(3),
+            RawFunctionKind::Foreign(Box::new(|gc, args| {
+               let arguments = Arguments::new(args);
+               gc.auto_strategy = AutoStrategy::Ceiling {
+                  next_run: arguments.nth(0).unwrap().ensure_number()? as usize,
+                  growth_factor: arguments.nth(1).unwrap().ensure_number()? as usize,
+               };
+               Ok(RawValue::from(()))
+            })),
+         )
+         .add_raw_static(
+            "collect",
+            Some(1),
+            RawFunctionKind::Control(Control::GcCollect),
+         )
+         .add_raw_static(
+            "allocated_bytes",
+            Some(1),
+            RawFunctionKind::Foreign(Box::new(|gc, _| {
+               let bytes = gc.allocated_bytes() as f64;
+               Ok(RawValue::from(bytes))
+            })),
+         ),
+   )?;
+
+   Ok(())
+}

--- a/mica-std/src/lib.rs
+++ b/mica-std/src/lib.rs
@@ -2,6 +2,7 @@
 
 mod builtins;
 mod core;
+mod gc;
 #[cfg(feature = "io")]
 mod io;
 

--- a/tests/stdlib/gc.mi
+++ b/tests/stdlib/gc.mi
@@ -1,0 +1,28 @@
+# Tests methods of the Gc type.
+
+func make_a_bunch_of_trash()
+   i = 0
+   while i < 100 do
+      i = i + 1
+      n = i.to_string
+      print(Gc.allocated_bytes)
+   end
+end
+
+# Manual collection
+Gc.disable()
+make_a_bunch_of_trash()
+before_collection = Gc.allocated_bytes
+Gc.collect()
+after_collection = Gc.allocated_bytes
+assert(after_collection < before_collection)
+
+# AlwaysRun strategy
+print("-- begin AlwaysRun")
+Gc.enable_always_run()
+make_a_bunch_of_trash()
+print("-- end AlwaysRun")
+
+# Ceiling strategy
+Gc.enable_with_ceiling(1024, 1.5 * 256)
+make_a_bunch_of_trash()


### PR DESCRIPTION
Adds the `Gc` type which allows for precisely controlling how the GC operates.

```
impl Gc
  # Disables automatic garbage collection; collect/0 static must be called to prevent leaks.
  func disable() static

  # Makes the GC run on most allocations. In most cases this is not what you want, as this is only useful for
  # debugging the GC.
  func enable_always_run() static

  # Makes the GC run periodically every time an amount of bytes is allocated.
  # `next_run` then gets updated to `allocated_bytes * growth_factor / 256`.
  # This is the default, with `next_run = 65536` and `growth_factor = 384`.
  func enable_with_ceiling(next_run, growth_factor) static

  # Triggers a garbage collection now.
  func collect() static

  # Returns the amount of bytes currently allocated by the GC.
  func allocated_bytes() static
end
```