### PR TITLE
Calling Mica from Rust (and more)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,5 +16,7 @@ jobs:
     - uses: actions/checkout@v2
     - name: Build
       run: cargo build --release -p mica-cli
-    - name: Run tests
+    - name: Run API tests
+      run: cargo test
+    - name: Run language tests
       run: ./tests/runner.sh

--- a/mica-hl/src/engine.rs
+++ b/mica-hl/src/engine.rs
@@ -4,7 +4,8 @@ use std::rc::Rc;
 
 use mica_language::ast::DumpAst;
 use mica_language::bytecode::{
-   BuiltinDispatchTables, Chunk, DispatchTable, Environment, Function, FunctionKind, Opcode, Opr24,
+   BuiltinDispatchTables, Chunk, DispatchTable, Environment, Function, FunctionKind,
+   FunctionSignature, Opcode, Opr24,
 };
 use mica_language::codegen::CodeGenerator;
 use mica_language::gc::{Gc, Memory};
@@ -14,8 +15,8 @@ use mica_language::value::{Closure, RawValue};
 use mica_language::vm::{self, Globals};
 
 use crate::{
-   ffvariants, BuiltType, Error, Fiber, ForeignFunction, LanguageErrorKind, MicaResultExt,
-   StandardLibrary, TryFromValue, TypeBuilder, UserData, Value,
+   ffvariants, BuiltType, Error, Fiber, ForeignFunction, StandardLibrary, TryFromValue,
+   TypeBuilder, UserData, Value,
 };
 
 /// The implementation of a raw foreign function.
@@ -150,6 +151,8 @@ impl Engine {
    ///
    /// - [`Error::Runtime`] - if a runtime error occurs - `function` isn't callable or an error is
    ///   raised during execution
+   /// - [`Error::TooManyArguments`] - if more arguments than the implementation can support is
+   ///   passed to the function
    pub fn call<T>(
       &mut self,
       function: Value,
@@ -168,9 +171,75 @@ impl Engine {
          Opcode::Call,
          // 1 has to be subtracted from the stack length there because the VM itself adds 1 to
          // count in the function argument.
-         Opr24::try_from(stack.len() - 1)
-            .map_err(|_| LanguageErrorKind::TooManyArguments)
-            .mica()?,
+         Opr24::try_from(stack.len() - 1).map_err(|_| Error::TooManyArguments)?,
+      ));
+      chunk.emit(Opcode::Halt);
+      let chunk = Rc::new(chunk);
+      let fiber = Fiber {
+         engine: self,
+         inner: vm::Fiber::new(chunk, stack),
+      };
+      fiber.trampoline()
+   }
+
+   /// Returns the unique ID of a method with a given name and arity.
+   ///
+   /// Note that there can only exist about 65 thousand unique method signatures. This is usually
+   /// not a problem as method names often repeat. Also note that unlike functions, a method can
+   /// only accept up to 256 arguments. Which, to be quite frankly honest, should be enough for
+   /// anyone.
+   ///
+   /// # Errors
+   ///
+   /// - [`Error::TooManyMethods`] - raised when too many unique method signatures exist at once
+   pub fn method_id(&mut self, signature: impl MethodSignature) -> Result<MethodId, Error> {
+      signature.to_method_id(&mut self.env)
+   }
+
+   /// Calls a method on a receiver with the given arguments.
+   ///
+   /// Note that if you're calling a method often, it's cheaper to precompute the method signature
+   /// into a [`MethodId`] by using the [`method_id`][`Self::method_id`] function, compared to
+   /// passing a name+arity pair every single time.
+   ///
+   /// # Errors
+   ///
+   /// - [`Error::Runtime`] - if a runtime error occurs - `function` isn't callable or an error is
+   ///   raised during execution
+   /// - [`Error::TooManyArguments`] - if more arguments than the implementation can support is
+   ///   passed to the function
+   /// - [`Error::TooManyMethods`] - if too many methods with different signatures exist at the same
+   ///   time
+   /// - [`Error::ArgumentCount`] - if `arguments.count()` does not match the argument count of the
+   ///   signature
+   pub fn call_method<T>(
+      &mut self,
+      receiver: Value,
+      signature: impl MethodSignature,
+      arguments: impl IntoIterator<Item = Value>,
+   ) -> Result<T, Error>
+   where
+      T: TryFromValue,
+   {
+      let method_id = signature.to_method_id(&mut self.env)?;
+      // Unwrapping here is fine because `to_method_id` ensures that a method with a given ID
+      // exists.
+      let signature = self.env.get_function_signature(method_id.0).unwrap();
+      let stack: Vec<_> =
+         Some(receiver).into_iter().chain(arguments).map(|x| x.to_raw(&mut self.gc)).collect();
+      let argument_count = u8::try_from(stack.len()).map_err(|_| Error::TooManyArguments)?;
+      if Some(argument_count as u16) != signature.arity {
+         return Err(Error::ArgumentCount {
+            // Unwrapping here is fine because signatures of methods created by `to_method_id`
+            // always have a static arity.
+            expected: signature.arity.unwrap() as usize - 1,
+            got: argument_count as usize - 1,
+         });
+      }
+      let mut chunk = Chunk::new(Rc::from("(call)"));
+      chunk.emit((
+         Opcode::CallMethod,
+         Opr24::pack((method_id.0, argument_count)),
       ));
       chunk.emit(Opcode::Halt);
       let chunk = Rc::new(chunk);
@@ -190,14 +259,8 @@ impl Engine {
    ///
    /// # Errors
    ///  - [`Error::TooManyGlobals`] - Too many globals with unique names were created
-   pub fn global_id(&mut self, name: &str) -> Result<GlobalId, Error> {
-      if let Some(slot) = self.env.get_global(name) {
-         Ok(GlobalId(slot))
-      } else {
-         Ok(GlobalId(
-            self.env.create_global(name).map_err(|_| Error::TooManyGlobals)?,
-         ))
-      }
+   pub fn global_id(&mut self, name: impl GlobalName) -> Result<GlobalId, Error> {
+      name.to_global_id(&mut self.env)
    }
 
    /// Sets a global variable that'll be available to scripts executed by the engine.
@@ -208,7 +271,7 @@ impl Engine {
    ///  - [`Error::TooManyGlobals`] - Too many globals with unique names were created
    pub fn set<G, T>(&mut self, id: G, value: T) -> Result<(), Error>
    where
-      G: ToGlobalId,
+      G: GlobalName,
       T: Into<Value>,
    {
       let id = id.to_global_id(&mut self.env)?;
@@ -225,7 +288,7 @@ impl Engine {
    ///  - [`Error::TypeMismatch`] - The type of the value is not convertible to `T`
    pub fn get<G, T>(&self, id: G) -> Result<T, Error>
    where
-      G: TryToGlobalId,
+      G: OptionalGlobalName,
       T: TryFromValue,
    {
       if let Some(id) = id.try_to_global_id(&self.env) {
@@ -353,18 +416,18 @@ mod global_id {
 }
 
 /// A trait for names convertible to global IDs.
-pub trait ToGlobalId: global_id::Sealed {
+pub trait GlobalName: global_id::Sealed {
    #[doc(hidden)]
    fn to_global_id(&self, env: &mut Environment) -> Result<GlobalId, Error>;
 }
 
-impl ToGlobalId for GlobalId {
+impl GlobalName for GlobalId {
    fn to_global_id(&self, _: &mut Environment) -> Result<GlobalId, Error> {
       Ok(*self)
    }
 }
 
-impl ToGlobalId for &str {
+impl GlobalName for &str {
    fn to_global_id(&self, env: &mut Environment) -> Result<GlobalId, Error> {
       Ok(if let Some(slot) = env.get_global(*self) {
          GlobalId(slot)
@@ -375,19 +438,62 @@ impl ToGlobalId for &str {
 }
 
 /// A trait for names convertible to global IDs.
-pub trait TryToGlobalId {
+pub trait OptionalGlobalName {
    #[doc(hidden)]
    fn try_to_global_id(&self, env: &Environment) -> Option<GlobalId>;
 }
 
-impl TryToGlobalId for GlobalId {
+impl OptionalGlobalName for GlobalId {
    fn try_to_global_id(&self, _: &Environment) -> Option<GlobalId> {
       Some(*self)
    }
 }
 
-impl TryToGlobalId for &str {
+impl OptionalGlobalName for &str {
    fn try_to_global_id(&self, env: &Environment) -> Option<GlobalId> {
       env.get_global(*self).map(GlobalId)
+   }
+}
+
+mod method_id {
+   use crate::MethodId;
+
+   pub trait Sealed {}
+
+   impl Sealed for MethodId {}
+   impl Sealed for (&str, u8) {}
+}
+
+/// An method ID unique to an engine, identifying a global variable.
+///
+/// Note that these IDs are not portable across different engine instances.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[repr(transparent)]
+pub struct MethodId(u16);
+
+/// Implemented by every type that can be used as a method signature.
+///
+/// See [`Engine::call_method`].
+pub trait MethodSignature: method_id::Sealed {
+   #[doc(hidden)]
+   fn to_method_id(&self, env: &mut Environment) -> Result<MethodId, Error>;
+}
+
+impl MethodSignature for MethodId {
+   fn to_method_id(&self, _: &mut Environment) -> Result<MethodId, Error> {
+      Ok(*self)
+   }
+}
+
+/// Tuples of string slices and `u8`s are a user-friendly representation of method signatures.
+/// For instance, `("cat", 1)` represents the method `cat/1`.
+impl MethodSignature for (&str, u8) {
+   fn to_method_id(&self, env: &mut Environment) -> Result<MethodId, Error> {
+      env.get_method_index(&FunctionSignature {
+         name: Rc::from(self.0),
+         arity: Some(self.1 as u16 + 1),
+      })
+      .map(MethodId)
+      .map_err(|_| Error::TooManyMethods)
    }
 }

--- a/mica-hl/src/engine.rs
+++ b/mica-hl/src/engine.rs
@@ -33,7 +33,8 @@ pub struct DebugOptions {
    pub dump_bytecode: bool,
 }
 
-/// An execution engine. Contains information about things like globals, registered types, etc.
+/// **Start here!** An execution engine. Contains information about things like globals, registered
+/// types, etc.
 pub struct Engine {
    pub(crate) env: Environment,
    pub(crate) globals: Globals,
@@ -464,7 +465,7 @@ mod method_id {
    impl Sealed for (&str, u8) {}
 }
 
-/// An method ID unique to an engine, identifying a global variable.
+/// An ID unique to an engine, identifying a method signature.
 ///
 /// Note that these IDs are not portable across different engine instances.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]

--- a/mica-hl/src/error.rs
+++ b/mica-hl/src/error.rs
@@ -21,6 +21,8 @@ pub enum Error {
    TooManyFunctions,
    /// Too many methods with different signatures were declared.
    TooManyMethods,
+   /// Too many arguments were passed to a method or a function.
+   TooManyArguments,
    /// A type mismatch occured.
    TypeMismatch {
       expected: Cow<'static, str>,
@@ -56,6 +58,7 @@ impl fmt::Display for Error {
          Self::TooManyGlobals => f.write_str("too many globals"),
          Self::TooManyFunctions => f.write_str("too many functions"),
          Self::TooManyMethods => f.write_str("too many methods with different signatures"),
+         Self::TooManyArguments => f.write_str("too many arguments passed to a function"),
          Self::TypeMismatch { expected, got } => {
             write!(f, "type mismatch, expected {expected} but got {got}")
          }

--- a/mica-hl/src/function.rs
+++ b/mica-hl/src/function.rs
@@ -118,26 +118,26 @@ impl<'a> From<&'a RawValue> for RawSelf<'a> {
 /// - Constant number of type checked arguments
 ///   - `fn (A, B, C, ...) -> R` where
 ///     - Each argument: [`TryFromValue`]
-///     - `R`: [`ToValue`]
+///     - `R`: [`Into`]`<`[`Value`]`>`
 ///   - `fn (A, B, C, ...) -> Result<R, E>`
 ///     - Each argument: [`TryFromValue`]
-///     - `R`: [`ToValue`]
+///     - `R`: [`Into`]`<`[`Value`]`>`
 ///   - `fn (Self, A, B, C, ...) -> R` where
-///     - `Self`: [`FromValueSelf`][`crate::FromValueSelf`] or
-///       [`FromValueSelfMut`][`crate::FromValueSelfMut`]
+///     - `Self`: [`SelfFromRawValue`][`crate::SelfFromRawValue`] or
+///       [`MutSelfFromRawValue`][`crate::MutSelfFromRawValue`]
 ///     - Each argument after `Self`: [`TryFromValue`]
-///     - `R`: [`ToValue`]
+///     - `R`: [`Into`]`<`[`Value`]`>`
 ///   - `fn (Self, A, B, C, ...) -> Result<R, E>`
-///     - `Self`: [`FromValueSelf`][`crate::FromValueSelf`] or
-///       [`FromValueSelfMut`][`crate::FromValueSelfMut`]
+///     - `Self`: [`SelfFromRawValue`][`crate::SelfFromRawValue`] or
+///       [`MutSelfFromRawValue`][`crate::MutSelfFromRawValue`]
 ///     - Each argument after `Self`: [`TryFromValue`]
-///     - `R`: [`ToValue`]
+///     - `R`: [`Into`]`<`[`Value`]`>`
 ///   - Due to a limitation in Rust's type system, a maximum of 8 arguments is supported now. If
 ///     more is needed, use the varargs versions described below.
 /// - Variable number of dynamically typed arguments
-///   - `fn (`[`Arguments`]`) -> R` where `R`: [`ToValue`]
+///   - `fn (`[`Arguments`]`) -> R` where `R`: [`Into`]`<`[`Value`]`>`
 ///   - `fn (`[`Arguments`]`) -> Result<R, E>` where
-///     - `R`: [`ToValue`]
+///     - `R`: [`Into`]`<`[`Value`]`>`
 ///     - `E`: [`std::error::Error`]
 ///
 /// The generic parameter `V` is not used inside the trait. Its only purpose is to allow for

--- a/mica-hl/src/function.rs
+++ b/mica-hl/src/function.rs
@@ -94,6 +94,7 @@ impl<'a> Arguments<'a> {
 /// Wrapper struct for marking functions that use the with-raw-self calling convention.
 ///
 /// This `Deref`s to the inner value.
+#[doc(hidden)]
 #[repr(transparent)]
 pub struct RawSelf<'a>(&'a RawValue);
 

--- a/mica-hl/src/lib.rs
+++ b/mica-hl/src/lib.rs
@@ -24,4 +24,10 @@ pub use value::*;
 
 pub use mica_language as language;
 pub use mica_language::gc::Gc;
-pub use mica_language::value::{RawValue, ValueKind};
+/// An **unsafe** value used internally in the VM.
+///
+/// Does not provide any safety guarantees as to GC'd object lifetimes.
+/// You almost always want [`Value`] instead of this.
+pub use mica_language::value::RawValue;
+/// The kind of a [`RawValue`].
+pub use mica_language::value::ValueKind as RawValueKind;

--- a/mica-hl/src/types.rs
+++ b/mica-hl/src/types.rs
@@ -176,8 +176,8 @@ where
 
    /// Adds an instance function to the struct.
    ///
-   /// The function must follow the "method" calling convention, in that it accepts `&`[`T`] or
-   /// `&mut `[`T`] as its first parameter.
+   /// The function must follow the "method" calling convention, in that it accepts `&T` or
+   /// `&mut T` as its first parameter.
    pub fn add_function<F, V>(self, name: &str, f: F) -> Self
    where
       V: ffvariants::Method<T>,

--- a/mica-hl/src/userdata.rs
+++ b/mica-hl/src/userdata.rs
@@ -13,7 +13,7 @@ use crate::Error;
 /// Due to limitations in Rust's type system each user-defined type must implement this.
 pub trait UserData: Any {}
 
-/// A type. This contains no data besides the type dtable and may be used to construct [`Object`]s.
+/// A type. This is used to represent user-defined Rust types in the VM (but not their instances).
 pub struct Type<T> {
    dtable: Gc<DispatchTable>,
    _data: PhantomData<T>,
@@ -42,6 +42,9 @@ where
 }
 
 /// A constructor of objects of type `T`.
+///
+/// See [`TypeBuilder::add_constructor`][`crate::TypeBuilder::add_constructor`] for how this is
+/// used.
 pub trait ObjectConstructor<T> {
    /// Constructs an object.
    fn construct(&self, instance: T) -> Object<T>;

--- a/mica-hl/src/value/mod.rs
+++ b/mica-hl/src/value/mod.rs
@@ -12,6 +12,7 @@ use crate::{Error, Object};
 pub use raw::*;
 
 /// A GC'd type whose content cannot be safely accessed.
+#[doc(hidden)]
 pub struct Hidden<T>(pub(crate) Gc<T>);
 
 impl<T> Clone for Hidden<T> {

--- a/mica-hl/src/value/raw.rs
+++ b/mica-hl/src/value/raw.rs
@@ -2,9 +2,9 @@ use std::any::Any;
 use std::hint::unreachable_unchecked;
 
 use mica_language::gc::{Gc, Memory};
-use mica_language::value::{RawValue, UserData, ValueKind};
+use mica_language::value::{RawValue, ValueKind};
 
-use crate::{Error, Hidden, Object, UnsafeMutGuard, UnsafeRefGuard, Value};
+use crate::{Error, Hidden, Object, UnsafeMutGuard, UnsafeRefGuard, UserData, Value};
 
 impl Value {
    /// Converts a safe value to a raw value. Gives management rights of the value to the given GC.
@@ -114,13 +114,13 @@ impl SelfFromRawValue for String {
 
 impl<T> SelfFromRawValue for T
 where
-   T: crate::UserData,
+   T: UserData,
 {
    type Guard = UnsafeRefGuard<T>;
 
    unsafe fn self_from_raw_value(value: &RawValue) -> Result<(&Self, Self::Guard), Error> {
       let user_data = value.get_raw_user_data_unchecked().get();
-      if let Some(object) = <dyn Any>::downcast_ref::<Object<T>>(user_data) {
+      if let Some(object) = user_data.as_any().downcast_ref::<Object<T>>() {
          object.unsafe_borrow()
       } else {
          unreachable_unchecked()
@@ -159,7 +159,7 @@ where
 
    unsafe fn mut_self_from_raw_value(value: &RawValue) -> Result<(&mut Self, Self::Guard), Error> {
       let user_data = value.get_raw_user_data_unchecked().get();
-      if let Some(object) = <dyn Any>::downcast_ref::<Object<T>>(user_data) {
+      if let Some(object) = user_data.as_any().downcast_ref::<Object<T>>() {
          object.unsafe_borrow_mut()
       } else {
          unreachable_unchecked()

--- a/mica-hl/src/value/raw.rs
+++ b/mica-hl/src/value/raw.rs
@@ -1,4 +1,3 @@
-use std::any::Any;
 use std::hint::unreachable_unchecked;
 
 use mica_language::gc::{Gc, Memory};

--- a/mica-language/src/vm.rs
+++ b/mica-language/src/vm.rs
@@ -90,12 +90,12 @@ pub struct Fiber {
 
 impl Fiber {
    /// Creates a new VM.
-   pub fn new(chunk: Rc<Chunk>) -> Self {
+   pub fn new(chunk: Rc<Chunk>, stack: Vec<RawValue>) -> Self {
       Self {
          pc: 0,
          chunk,
          closure: None,
-         stack: Vec::new(),
+         stack,
          stack_bottom: 0,
          open_upvalues: Vec::new(),
          call_stack: Vec::new(),

--- a/mica-std/src/io.rs
+++ b/mica-std/src/io.rs
@@ -3,9 +3,8 @@
 //! This feature is disabled by default as mica-std's I/O facilities are still under construction.
 
 use std::io;
-use std::rc::Rc;
 
-use mica_hl::{Engine, TypeBuilder, UserData};
+use mica_hl::{Engine, MutSelfFromRawValue, SelfFromRawValue, TypeBuilder, UserData};
 
 struct File {
    // The file is `None` if the user calls `close/0`.
@@ -46,7 +45,7 @@ pub fn load_io(engine: &mut Engine) -> Result<(), mica_hl::Error> {
    engine.add_type(
       TypeBuilder::<File>::new("File")
          .add_constructor("open", |ctor| {
-            move |name: Rc<str>| -> io::Result<_> { Ok(ctor.construct(File::open(&name)?)) }
+            move |name: String| -> io::Result<_> { Ok(ctor.construct(File::open(&name)?)) }
          })
          .add_function("close", File::close),
    )?;

--- a/src/lib.md
+++ b/src/lib.md
@@ -61,8 +61,9 @@ let mut script = engine.compile("hello.mi", r#" print("Hello, world!") "#)?;
 # Ok(())
 # }
 ```
-Now that you have a script, you can begin executing it by calling `script.start()`. This will start
-up a new [`Fiber`], which represents a pausable thread of execution.<br>
+Now that you have a script, you can begin executing it by calling
+`script.`[`start`][`Script::start`]`()`. This will start up a new [`Fiber`], which represents a
+pausable thread of execution.<br>
 <sup>Though currently there's no way to signal that you want to pause execution from within Mica.</sup>
 
 ```rust
@@ -94,7 +95,7 @@ while let Some(value) = fiber.resume::<Value>()? {
 ```
 If you only care about the final value returned by the fiber, you can call
 [`trampoline`][`Fiber::trampoline`] instead. The name comes from the fact that the function
-_bounces_ into and out of the VM until execution is done.
+bounces into and out of the VM until execution is done.
 
 Note that this function discards all intermediary values returned by the VM.
 ```rust
@@ -169,7 +170,7 @@ assert_eq!(x, 1.0);
 
 ## Calling Rust from Mica
 
-Mica wouldn't be an embeddable scripting language worth anybody's time if it didn't have a way of
+Mica wouldn't be an embeddable scripting language worth your time if it didn't have a way of
 calling Rust functions. To register a Rust function in the VM, [`Engine::add_function`] can be used:
 ```rust
 # use mica::Value;
@@ -186,9 +187,9 @@ assert_eq!(
 ```
 In the Mica VM Rust functions are named "foreign", because they are foreign to the VM. This
 nomenclature is also used in this crate. Apart from this, Rust functions that are registered into
-the global scope, and do not have a `self` parameter, are called _bare_ in the documentation.
+the global scope, and do not have a `self` parameter, are called "bare" in the documentation.
 
-Rust functions registered in the VM can also be fallible, and return a [`Result`]`<T, E>`.
+Rust functions registered in the VM can also be fallible, and return a [`Result<T, E>`].
 ```rust
 # use mica::Value;
 # fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -216,8 +217,8 @@ raise a runtime error in the VM.
 # engine.add_function("parse_integer_with_radix", |s: String, radix: u32| {
 #    usize::from_str_radix(&s, radix)
 # })?;
-assert!(engine.start("ffi.mi", r#" parse_integer_with_radix() "#)?.trampoline::<f64>().is_err());
-assert!(engine.start("ffi.mi", r#" parse_integer_with_radix(1, 16) "#)?.trampoline::<f64>().is_err());
+assert!(engine.start("ffi.mi", r#" parse_integer_with_radix()         "#)?.trampoline::<f64>().is_err());
+assert!(engine.start("ffi.mi", r#" parse_integer_with_radix(1, 16)    "#)?.trampoline::<f64>().is_err());
 assert!(engine.start("ffi.mi", r#" parse_integer_with_radix("aa", 16) "#)?.trampoline::<f64>().is_ok());
 # Ok(())
 # }
@@ -238,12 +239,14 @@ the `Counter` type from the example code at the top of the page, but in Rust.
 First of all, for Rust type system reasons, your type needs to implement [`UserData`].
 
 ```rust
+use mica::UserData;
+
 struct Counter {
    value: usize,
    increment: usize,
 }
 
-impl mica::UserData for Counter {}
+impl UserData for Counter {}
 ```
 
 With a type set up, you can then create a [`TypeBuilder`] and use it in [`Engine::add_type`].
@@ -290,6 +293,16 @@ assert_eq!(
 );
 # Ok(())
 # }
+```
+
+Unfortunately Rust's orphan rules prevent traits from being implemented on types from other crates,
+so the only way of binding someone else's type is by creating a newtype struct and implementing
+`UserData` on it.
+```rust
+# use mica::UserData;
+struct File(std::fs::File);
+
+impl UserData for File {}
 ```
 
 ## Calling Mica from Rust

--- a/src/lib.md
+++ b/src/lib.md
@@ -291,3 +291,31 @@ assert_eq!(
 # Ok(())
 # }
 ```
+
+## Calling Mica from Rust
+
+It's also possible to call functions from the Mica VM in Rust. For that, the [`Engine::call`]
+function may be used.
+
+```rust
+# use mica::Value;
+# fn main() -> Result<(), Box<dyn std::error::Error>> {
+# let mut engine = mica::Engine::new(mica::std::lib());
+# mica::std::load(&mut engine);
+let get_greeting =
+   engine
+      .start(
+         "function.mi",
+         r#"
+            (func (x)
+               "Hello, ".cat(x).cat("!")
+            end)
+         "#
+      )?
+      .trampoline()?;
+let greeting: String = engine.call(get_greeting, [Value::from("world")])?;
+assert_eq!(greeting, "Hello, world!");
+
+# Ok(())
+# }
+```

--- a/src/lib.md
+++ b/src/lib.md
@@ -1,0 +1,293 @@
+**Mica** is an embeddable scripting language for Rust.
+
+- Features a **human-friendly** syntax inspired by Ruby and Lua.
+- It's **simple** yet **extensible** by providing a small set of flexible features.
+- It's **easily embeddable** into existing programs.
+
+```text
+## Hello, Mica!
+
+struct Counter
+
+impl Counter
+   func new(start, increment) constructor
+      @value = start
+      @increment = increment
+   end
+
+   func value() @value end
+
+   func increment()
+      @value = @value + @increment
+   end
+end
+
+c = Counter.new(1, 1)
+while c.value < 100 do
+   print(c.value)
+   if c.value.mod(2) == 0 do
+      print("even!")
+   end
+   c.increment()
+end
+```
+
+# Getting started
+
+Seeing you're here, you probably want to embed Mica into your own program. Worry not! There's an
+easy-to-use, high-level API just waiting to be discovered by adventurous people like you.
+
+To start out, build an [`Engine`] and load the [standard library][`std`] into it:
+```rust
+use mica::Engine;
+
+let mut engine = Engine::new(mica::std::lib());
+mica::std::load(&mut engine);
+```
+
+## Running code
+
+Before we can run code, we must compile it into a [`Script`]. Note that compiling a script
+mutably borrows your engine, and it cannot be used for anything else while a compiled script exists.
+This is because a script must only ever be run in the engine it was compiled in.
+Thus, the script mutably borrows the engine it was compiled by, so that you don't have to worry
+about confusing two engines.
+```rust
+# fn main() -> Result<(), Box<dyn std::error::Error>> {
+# let mut engine = mica::Engine::new(mica::std::lib());
+# mica::std::load(&mut engine);
+// The first argument passed is the file name, which is used in error messages.
+let mut script = engine.compile("hello.mi", r#" print("Hello, world!") "#)?;
+# Ok(())
+# }
+```
+Now that you have a script, you can begin executing it by calling `script.start()`. This will start
+up a new [`Fiber`], which represents a pausable thread of execution.<br>
+<sup>Though currently there's no way to signal that you want to pause execution from within Mica.</sup>
+
+```rust
+# fn main() -> Result<(), Box<dyn std::error::Error>> {
+# let mut engine = mica::Engine::new(mica::std::lib());
+# mica::std::load(&mut engine);
+# let mut script = engine.compile("hello.mi", r#" print("Hello, world!") "#)?;
+let mut fiber = script.start();
+# Ok(())
+# }
+```
+A fiber doesn't start running immediately though. To make it start interpreting your bytecode, call
+[`resume`][`Fiber::resume`]:
+```rust
+# fn main() -> Result<(), Box<dyn std::error::Error>> {
+# let mut engine = mica::Engine::new(mica::std::lib());
+# mica::std::load(&mut engine);
+# let mut script = engine.compile("hello.mi", r#" print("Hello, world!") "#)?;
+# let mut fiber = script.start();
+use mica::Value;
+while let Some(value) = fiber.resume::<Value>()? {
+   println!("{value:?}");
+}
+// Output:
+// Hello, world!
+// nil
+# Ok(())
+# }
+```
+If you only care about the final value returned by the fiber, you can call
+[`trampoline`][`Fiber::trampoline`] instead. The name comes from the fact that the function
+_bounces_ into and out of the VM until execution is done.
+
+Note that this function discards all intermediary values returned by the VM.
+```rust
+# use mica::Value;
+# fn main() -> Result<(), Box<dyn std::error::Error>> {
+# let mut engine = mica::Engine::new(mica::std::lib());
+# mica::std::load(&mut engine);
+# let mut script = engine.compile("hello.mi", r#" print("Hello, world!") "#)?;
+# let mut fiber = script.start();
+let result: Value = fiber.trampoline()?;
+println!("{result:?}");
+# Ok(())
+# }
+```
+
+## Working with values
+
+As shown above, running a script produces one or more values. This is an important feature of Mica –
+it's an _expression-oriented_ language. Everything you could possibly think of produces a value.
+
+To make working with values less annoying, types that can be obtained from Mica's dynamically-typed
+values implement the [`TryFromValue`] trait, and each function returning values from the VM
+conveniently converts the returned value to a user-specified type.
+```rust
+# use mica::Value;
+# fn main() -> Result<(), Box<dyn std::error::Error>> {
+# let mut engine = mica::Engine::new(mica::std::lib());
+# mica::std::load(&mut engine);
+// Tip: A fiber can be started immediately after compiling a script, by using Engine::start.
+let mut fiber = engine.start("arithmetic.mi", r#" 2 + 2 * 2 "#)?;
+let result: f64 = fiber.trampoline()?;
+assert_eq!(result, 6.0);
+# Ok(())
+# }
+```
+
+Evaluating arbitrary code is fun, but it's not very useful unless we can give it some inputs from
+our program. For that, we can use _globals_. Globals can be set using [`Engine::set`], and retrieved
+using [`Engine::get`].
+```rust
+# use mica::Value;
+# fn main() -> Result<(), Box<dyn std::error::Error>> {
+# let mut engine = mica::Engine::new(mica::std::lib());
+# mica::std::load(&mut engine);
+engine.set("x", 1.0f64);
+engine.set("y", 2.0f64);
+let result: f64 = engine.start("globals.mi", r#" x + y * 10 "#)?.trampoline()?;
+assert_eq!(result, 21.0);
+# Ok(())
+# }
+```
+Scripts can also set globals, but this functionality is planned to be removed at some point in favor
+of just returning values.
+```rust
+# use mica::Value;
+# fn main() -> Result<(), Box<dyn std::error::Error>> {
+# let mut engine = mica::Engine::new(mica::std::lib());
+# mica::std::load(&mut engine);
+// The unit type implements TryFromValue that expects a nil value.
+let _: () =
+   engine.start(
+      "code.mi",
+      r#" x = 1
+          nil "# // Explicitly return nil, because every assignment evaluates to its right-hand side
+   )?
+   .trampoline()?;
+let x: f64 = engine.get("x")?;
+assert_eq!(x, 1.0);
+# Ok(())
+# }
+```
+
+## Calling Rust from Mica
+
+Mica wouldn't be an embeddable scripting language worth anybody's time if it didn't have a way of
+calling Rust functions. To register a Rust function in the VM, [`Engine::add_function`] can be used:
+```rust
+# use mica::Value;
+# fn main() -> Result<(), Box<dyn std::error::Error>> {
+# let mut engine = mica::Engine::new(mica::std::lib());
+# mica::std::load(&mut engine);
+engine.add_function("double", |x: f64| x * x)?;
+assert_eq!(
+   engine.start("ffi.mi", "double(2)")?.trampoline::<f64>()?,
+   4.0
+);
+# Ok(())
+# }
+```
+In the Mica VM Rust functions are named "foreign", because they are foreign to the VM. This
+nomenclature is also used in this crate. Apart from this, Rust functions that are registered into
+the global scope, and do not have a `self` parameter, are called _bare_ in the documentation.
+
+Rust functions registered in the VM can also be fallible, and return a [`Result`]`<T, E>`.
+```rust
+# use mica::Value;
+# fn main() -> Result<(), Box<dyn std::error::Error>> {
+# let mut engine = mica::Engine::new(mica::std::lib());
+# mica::std::load(&mut engine);
+// Note that the API also understands numeric types other than `f64`. However, the only type of
+// numbers Mica supports natively is `f64`, so converting from bigger types incurs a precision loss.
+engine.add_function("parse_integer_with_radix", |s: String, radix: u32| {
+   usize::from_str_radix(&s, radix)
+})?;
+assert_eq!(
+   engine.start("ffi.mi", r#" parse_integer_with_radix("FF", 16) "#)?.trampoline::<f64>()?,
+   255.0
+);
+# Ok(())
+# }
+```
+Calling a Rust function with the incorrect number of arguments, or incorrect argument types, will
+raise a runtime error in the VM.
+```rust
+# use mica::Value;
+# fn main() -> Result<(), Box<dyn std::error::Error>> {
+# let mut engine = mica::Engine::new(mica::std::lib());
+# mica::std::load(&mut engine);
+# engine.add_function("parse_integer_with_radix", |s: String, radix: u32| {
+#    usize::from_str_radix(&s, radix)
+# })?;
+assert!(engine.start("ffi.mi", r#" parse_integer_with_radix() "#)?.trampoline::<f64>().is_err());
+assert!(engine.start("ffi.mi", r#" parse_integer_with_radix(1, 16) "#)?.trampoline::<f64>().is_err());
+assert!(engine.start("ffi.mi", r#" parse_integer_with_radix("aa", 16) "#)?.trampoline::<f64>().is_ok());
+# Ok(())
+# }
+```
+Due to limitations of Rust's type system, strongly typed functions like the one in the example above
+can only have up to 8 arguments. If more arguments, or a variable amount is needed, a function can
+accept [`Arguments`] as its sole argument, and use it to process arguments.
+
+Do note however that [`Arguments`]' API is comparatively low-level and will have you working with
+[`RawValue`]s that are unsafe in many ways. If you really need that many arguments, maybe it's time
+to rethink your APIs.
+
+## Rust types in Mica
+
+Mica allows for registering arbitrary user-defined types in the VM. As an example, let's implement
+the `Counter` type from the example code at the top of the page, but in Rust.
+
+First of all, for Rust type system reasons, your type needs to implement [`UserData`].
+
+```rust
+struct Counter {
+   value: usize,
+   increment: usize,
+}
+
+impl mica::UserData for Counter {}
+```
+
+With a type set up, you can then create a [`TypeBuilder`] and use it in [`Engine::add_type`].
+
+```rust
+# use mica::Value;
+# fn main() -> Result<(), Box<dyn std::error::Error>> {
+# let mut engine = mica::Engine::new(mica::std::lib());
+# mica::std::load(&mut engine);
+# struct Counter {
+#    value: usize,
+#    increment: usize,
+# }
+# impl mica::UserData for Counter {}
+use mica::TypeBuilder;
+
+impl Counter {
+   fn value(&self) -> usize { self.value }
+   fn increment(&mut self) {
+      self.value += self.increment;
+   }
+}
+
+engine.add_type(
+   // The argument passed to TypeBuilder::new is the name of the global that we want to bind the
+   // type under.
+   TypeBuilder::<Counter>::new("Counter")
+      .add_constructor("new", |ctor| move |value: usize, increment: usize| {
+         ctor.construct(Counter { value, increment })
+      })
+      .add_function("value", Counter::value)
+      .add_function("increment", Counter::increment)
+);
+
+assert_eq!(
+   engine
+      .start("type.mi", r#"
+         counter = Counter.new(10, 2)
+         counter.increment()
+         counter.value
+      "#)?
+      .trampoline::<f64>()?,
+   12.0,
+);
+# Ok(())
+# }
+```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-//! **Mica** is an embeddable scripting language for Rust.
+#![doc = include_str!("lib.md")]
 
 pub use mica_hl::*;
 pub use mica_std as std;


### PR DESCRIPTION
This PR implements an API for calling Mica from Rust, as well as fixing some bugs in the existing API that crawled into the code as a result of the GC refactoring.