### PR TITLE
New function syntax

### DIFF
--- a/docs/language.md
+++ b/docs/language.md
@@ -573,20 +573,24 @@ In fact, a bare `break` is syntax sugar for `break nil`.
 
 A function definition creates a new function and assigns it to a variable. The syntax is:
 ```mica
-func name(param1, param2, param3)
-   # body
-end
+func name(param1, param2, param3) = expression
 ```
 This syntax is almost exactly the same as:
 ```mica
 # Introduce the variable into scope first, so that the function can be called recursively.
 name = nil
-name = func (param1, param2, param3)
-   # body
+name = func (param1, param2, param3) = expression
+```
+However, the `func name() = expression` form is preferred as it assigns a name to the function, which is
+visible in stack traces. Anonymous functions have the name `<anonymous>`.
+
+To create a multiline function, a `do` block can be used as the expression:
+```mica
+func say_nice_things() = do
+   print("Hey!")
+   print("You look great today!")
 end
 ```
-However, the `func name() end` form is preferred as it assigns a name to the function, which is
-visible in stack traces. Anonymous functions have the name `<anonymous>`.
 
 ### Struct definitions
 
@@ -625,9 +629,8 @@ functions can be used as a way of putting functions into namespaces.
 struct Greetings
 
 impl Greetings
-   func get(for_whom) static
+   func get(for_whom) static =
       "Hello, ".cat(for_whom).cat("!")
-   end
 end
 
 assert(Greetings.get("world") == "Hello, world!")
@@ -647,13 +650,13 @@ declared in the first one.
 ```mica
 struct Vector
 impl Vector
-   func new(x, y) constructor
+   func new(x, y) constructor = do
       # Declare fields that will store the X/Y coordinates of the vector.
       @x = x
       @y = y
    end
 
-   func zero() constructor
+   func zero() constructor = do
       # Additional constructors must assign to the same set of fields as the first constructor.
       @x = 0
       @y = 0
@@ -661,15 +664,13 @@ impl Vector
 
    # Now we can declare functions that operate on instances of the type.
 
-   func len2()
+   func len2() =
       @x * @x + @y * @y
-   end
 
-   func len()
+   func len() =
       # The `self` variable may be used to refer to the instance the function was called on, ie.
       # the left-hand side of the dot.
       self.len2.sqrt
-   end
 end
 
 v = Vector.new(3, 4)
@@ -695,9 +696,8 @@ type system.
 The implemented struct can be any expression, so nothing prevents you from doing this:
 ```mica
 struct S
-func obtain_struct()
+func obtain_struct() =
    S
-end
 
 impl obtain_struct()
    # ...
@@ -712,13 +712,11 @@ end
 Apart from this, an `impl` block returns the implemented struct, so eg. returning a newly
 implemented struct from a function is possible.
 ```
-func make_me_a_struct()
+func make_me_a_struct() =
    impl struct TheStruct
-      func say_hi() static
+      func say_hi() static =
          print("Hi!!")
-      end
    end
-end
 
 AStruct = make_me_a_struct()
 AStruct.say_hi()

--- a/mica-language/src/common.rs
+++ b/mica-language/src/common.rs
@@ -85,6 +85,7 @@ pub enum ErrorKind {
    CommaExpected,
    ColonExpectedAfterDictKey,
    RightBracketExpectedToCloseEmptyDict,
+   MissingFunctionBody,
 
    // Code generator
    VariableDoesNotExist(Rc<str>),
@@ -169,6 +170,7 @@ impl std::fmt::Display for ErrorKind {
          Self::CommaExpected => write!(f, "comma ',' expected"),
          Self::ColonExpectedAfterDictKey => write!(f, "colon ':' expected after dict key"),
          Self::RightBracketExpectedToCloseEmptyDict => write!(f, "right bracket ']' expected to close empty dict literal [:]"),
+         Self::MissingFunctionBody => write!(f, "missing function body ('= expression')"),
 
          Self::VariableDoesNotExist(name) => write!(f, "variable '{name}' does not exist"),
          Self::InvalidAssignment => write!(f, "invalid left hand side of assignment"),

--- a/mica-language/src/parser.rs
+++ b/mica-language/src/parser.rs
@@ -379,9 +379,8 @@ impl Parser {
          .with_children(parameters)
          .done();
 
-      let mut body = Vec::new();
-      self.parse_terminated_block(&func_token, &mut body, |k| *k == TokenKind::End)?;
-      let _end = self.lexer.next_token();
+      let _equals = self.expect(TokenKind::Assign, |_| ErrorKind::MissingFunctionBody)?;
+      let body = vec![self.parse_expression(0)?];
 
       Ok(self
          .ast

--- a/src/lib.md
+++ b/src/lib.md
@@ -319,9 +319,7 @@ let get_greeting =
       .start(
          "function.mi",
          r#"
-            (func (x)
-               "Hello, ".cat(x).cat("!")
-            end)
+            (func (x) = "Hello, ".cat(x).cat("!"))
          "#
       )?
       .trampoline()?;
@@ -345,13 +343,12 @@ let greeter_type =
             struct Greeter
 
             impl Greeter
-               func new(template) constructor
+               func new(template) constructor = do
                   @template = template
                end
 
-               func greetings(for_whom)
+               func greetings(for_whom) =
                   @template.replace("{target}", for_whom)
-               end
             end
 
             Greeter

--- a/tests/gc/delete-function-during-call.mi
+++ b/tests/gc/delete-function-during-call.mi
@@ -3,13 +3,13 @@
 struct LinkedList
 
 impl LinkedList
-   func new(value, next) constructor
+   func new(value, next) constructor = do
       @value = value
       @next = next
    end
 end
 
-func make_long_list()
+func make_long_list() = do
    i = 0
    list = nil
    # Allocate enough objects to cause a collection to happen.
@@ -20,7 +20,7 @@ func make_long_list()
    list
 end
 
-func hi()
+func hi() = do
    hi = nil
    make_long_list()
    nil

--- a/tests/gc/stack-overflow-1.mi
+++ b/tests/gc/stack-overflow-1.mi
@@ -3,7 +3,7 @@
 struct LinkedList
 
 impl LinkedList
-   func new(value, next) constructor
+   func new(value, next) constructor = do
       @value = value
       @next = next
    end

--- a/tests/gc/stress-1.mi
+++ b/tests/gc/stress-1.mi
@@ -3,7 +3,7 @@
 struct Garbage
 
 impl Garbage
-   func new() constructor
+   func new() constructor = do
       @trash = 1
    end
 end

--- a/tests/gc/stress-2.mi
+++ b/tests/gc/stress-2.mi
@@ -3,13 +3,13 @@
 struct LinkedList
 
 impl LinkedList
-   func new(value, next) constructor
+   func new(value, next) constructor = do
       @value = value
       @next = next
    end
 end
 
-func make_long_list()
+func make_long_list() = do
    i = 0
    list = nil
    while i < 1000 do

--- a/tests/language/closures.mi
+++ b/tests/language/closures.mi
@@ -1,24 +1,19 @@
 # Checks if closures work.
 
 # Closures without captures act like normal functions.
-f = func (x)
-   x + 1
-end
+f = func (x) = x + 1
 assert(f(1) == 2)
 
 # Closures can have constant captures.
-func adder(x)
-   (func (y)
-      x + y
-   end)
-end
+func adder(x) =
+   func (y) = x + y
 add_two = adder(2)
 assert(add_two(2) == 4)
 
 # Closures may modify captured variables.
-func counter(start, increment)
+func counter(start, increment) = do
    i = start
-   (func ()
+   (func () = do
       value = i
       i = i + increment
       value
@@ -35,40 +30,29 @@ get = nil
 inc = nil
 do
    count = 1
-   get = func ()
-      count
-   end
-   inc = func ()
-      count = count + 1
-   end
+   get = func () = count
+   inc = func () = count = count + 1
 end
 assert(get() == 1)
 assert(inc() == 2)
 assert(get() == 2)
 
 # A closure may capture a variable that's captured in another closure.
-func double_indirection(x)
-   (func (y)
-      (func (z)
+func double_indirection(x) =
+   func (y) =
+      func (z) =
          x + y + z
-      end)
-   end)
-end
 w = double_indirection(1)(2)(3)
 assert(w == 6)
 
 # A doubly-indirected variable (like above) can still be modified like usual.
 set = nil
 get = nil
-func double_indirection_mut()
+func double_indirection_mut() = do
    val = 1
-   (func ()
-      set = func (x)
-         val = x
-      end
-      get = func ()
-         val
-      end
+   (func () = do
+      set = func (x) = val = x
+      get = func () = val
    end)
 end
 setup = double_indirection_mut()

--- a/tests/language/functions.mi
+++ b/tests/language/functions.mi
@@ -1,31 +1,29 @@
 # Checks that functions work.
 # See closures.mi for the test cases regarding closures.
 
-# An empty function is legal and should return nil.
-func nop() end
-assert(nop() == nil)
+# Functions can be declared, in this case to not do anything.
+func nop() = nil
 
 # Function items return nil.
 assert(do
-   func f() end
+   func f() = nil
 end == nil)
 
 # Arguments should not affect the function's result.
-func discard(x) end
+func discard(x) = nil
 assert(discard(1) == nil)
 
 # A function is equal to itself, but never to other functions.
 assert(nop == nop)
 assert(nop != discard)
 
-# The last expression in a function is its return value.
-func add_one(x)
+# A function returns the value after `=`.
+func add_one(x) =
    x + 1
-end
 assert(add_one(1) == 2)
 
 # New locals can be declared in functions.
-func declare_some_locals(x)
+func declare_some_locals(x) = do
    y = x + 1
    assert(y == x + 1)
    x + y
@@ -33,17 +31,16 @@ end
 assert(declare_some_locals(2) == 5)
 
 # Functions can be called recursively.
-func fib(n)
+func fib(n) =
    if n == 0 or n == 1 do n
    else fib(n - 1) + fib(n - 2)
    end
-end
 assert(fib(20) == 6765)
 # Deep recursion may take a while but should never crash the program (unless we run out of memory).
 assert(fib(30) == 832040)
 
 # `return` can be used to return from the function early.
-func test_return(x)
+func test_return(x) = do
    if x == 1 do
       return 123
    end

--- a/tests/language/operators.mi
+++ b/tests/language/operators.mi
@@ -9,7 +9,7 @@ assert(!!nil == false)
 assert(!!false == false)
 assert(!!1 == true)
 assert(!!"" == true)
-assert(!!func () end == true)
+assert(!!(func () = nil) == true)
 struct S
 assert(!!S == true)
 

--- a/tests/language/struct.mi
+++ b/tests/language/struct.mi
@@ -12,9 +12,8 @@ assert(struct Test2 != nil)
 
 # A struct can be implemented with arbitrary methods.
 impl struct Greetings
-   func get(for_whom) static
+   func get(for_whom) static =
       "Hello, ".cat(for_whom).cat("!")
-   end
 end
 
 assert(Greetings.get("World") == "Hello, World!")
@@ -22,31 +21,29 @@ assert(Greetings.get("World") == "Hello, World!")
 # A struct can have a constructor that sets its fields up.
 # It can also have instance methods.
 impl struct Vector
-   func new(x, y) constructor
+   func new(x, y) constructor = do
       @x = x
       @y = y
    end
 
    # There can be more than one constructor. Each constructor after the first one must assign
    # the same set of fields.
-   func zero() constructor
+   func zero() constructor = do
       @x = 0
       @y = 0
    end
 
-   func x() @x end
-   func y() @y end
+   func x() = @x
+   func y() = @y
 
-   func set_x(x) @x = x end
-   func set_y(y) @y = y end
+   func set_x(x) = @x = x
+   func set_y(y) = @y = y
 
-   func len_sq()
+   func len_sq() =
       @x * @x + @y * @y
-   end
 
-   func len()
+   func len() =
       self.len_sq.sqrt
-   end
 end
 
 v = Vector.new(1, 2)

--- a/tests/stdlib/gc.mi
+++ b/tests/stdlib/gc.mi
@@ -1,6 +1,6 @@
 # Tests methods of the Gc type.
 
-func make_a_bunch_of_trash()
+func make_a_bunch_of_trash() = do
    i = 0
    while i < 100 do
       i = i + 1

--- a/tests/stdlib/number.mi
+++ b/tests/stdlib/number.mi
@@ -1,8 +1,7 @@
 # Tests for Number methods.
 
-func approx_equal(x, y, epsilon)
+func approx_equal(x, y, epsilon) =
    (x - y).abs <= epsilon
-end
 
 assert(Number.nan != Number.nan)
 assert(Number.nan.is_nan)


### PR DESCRIPTION
Functions are now declared like `func name(x, y, z) = expression` instead of `func name(x, y, z) body end`.