### PR TITLE
Fix global ID collision in `Environment::create_global`

### DIFF
--- a/mica-language/src/bytecode.rs
+++ b/mica-language/src/bytecode.rs
@@ -652,9 +652,13 @@ impl Environment {
    /// Tries to create a global. Returns the global slot number, or an error if there are too many
    /// globals.
    pub fn create_global(&mut self, name: &str) -> Result<Opr24, ErrorKind> {
-      let slot = Opr24::try_from(self.globals.len()).map_err(|_| ErrorKind::TooManyGlobals)?;
-      self.globals.insert(name.to_owned(), slot);
-      Ok(slot)
+      if self.globals.contains_key(name) {
+         Ok(*self.globals.get(name).unwrap())
+      } else {
+         let slot = Opr24::try_from(self.globals.len()).map_err(|_| ErrorKind::TooManyGlobals)?;
+         self.globals.insert(name.to_owned(), slot);
+         Ok(slot)
+      }
    }
 
    /// Tries to look up a global. Returns `None` if the global doesn't exist.

--- a/mica-language/src/codegen.rs
+++ b/mica-language/src/codegen.rs
@@ -238,7 +238,6 @@ impl<'e> CodeGenerator<'e> {
          Ok(place)
       } else {
          let slot = self.env.create_global(name)?;
-         println!("global created {slot} -> {name}");
          Ok(VariablePlace::Global(slot))
       }
    }

--- a/mica-language/src/codegen.rs
+++ b/mica-language/src/codegen.rs
@@ -238,6 +238,7 @@ impl<'e> CodeGenerator<'e> {
          Ok(place)
       } else {
          let slot = self.env.create_global(name)?;
+         println!("global created {slot} -> {name}");
          Ok(VariablePlace::Global(slot))
       }
    }

--- a/tests/language/variable/global-shadow.test.mi
+++ b/tests/language/variable/global-shadow.test.mi
@@ -1,0 +1,10 @@
+# Ensures that globals can be shadowed by user scripts.
+
+# The declaration below shadows print, and *should* work ↓
+func print() = nil
+func another_global() = nil
+
+print = 1
+another_global = 2
+
+assert(print != another_global)


### PR DESCRIPTION
This should allow for shadowing globals as intended.