### PR TITLE
Add `List.iter/0`

### DIFF
--- a/src/corelib/builtins/list.rs
+++ b/src/corelib/builtins/list.rs
@@ -1,4 +1,7 @@
-use crate::{ll::value::RawValue, Arguments, MethodParameterCount, RawFunctionKind, TypeBuilder};
+use crate::{
+    corelib::iterators::list::ListIter, ll::value::RawValue, Arguments, IntoValue,
+    MethodParameterCount, RawFunctionKind, TypeBuilder,
+};
 
 pub(crate) fn define(builder: TypeBuilder<Vec<RawValue>>) -> TypeBuilder<Vec<RawValue>> {
     builder
@@ -43,6 +46,16 @@ pub(crate) fn define(builder: TypeBuilder<Vec<RawValue>>) -> TypeBuilder<Vec<Raw
         .add_function("rotate_right", |v: &mut Vec<RawValue>, n: usize| v.rotate_right(n))
         .add_function("swap", |v: &mut Vec<RawValue>, a: usize, b: usize| v.swap(a, b))
         .add_function("clone", |v: &Vec<RawValue>| v.clone())
+        // TODO: It should be possible to implement this without raw functions in the future.
+        .add_raw_function(
+            "iter",
+            MethodParameterCount::from_count_with_self(1),
+            RawFunctionKind::Foreign(Box::new(|env, gc, args| {
+                let arguments = Arguments::new(args, env);
+                let iter = unsafe { ListIter::new(*arguments.raw_self()) };
+                Ok(iter.into_value_with_environment(env).to_raw(gc))
+            })),
+        )
 }
 
 #[derive(Debug)]

--- a/src/corelib/iterators.rs
+++ b/src/corelib/iterators.rs
@@ -1,10 +1,12 @@
-use self::counters::load_counters;
+use self::{counters::load_counters, list::load_list_iter};
 use crate::{Engine, Error};
 
 mod counters;
+pub(crate) mod list;
 
 pub(crate) fn load_iterators(engine: &mut Engine) -> Result<(), Error> {
     load_counters(engine)?;
+    load_list_iter(engine)?;
 
     Ok(())
 }

--- a/src/corelib/iterators/counters.mi
+++ b/src/corelib/iterators/counters.mi
@@ -1,2 +1,0 @@
-func countup(min, max) = CountUp.new(min, max)
-func countdown(max, min) = CountDown.new(max, min)

--- a/src/corelib/iterators/counters.rs
+++ b/src/corelib/iterators/counters.rs
@@ -61,21 +61,21 @@ impl UserData for CountDown {}
 pub(crate) fn load_counters(engine: &mut Engine) -> Result<(), Error> {
     engine.add_type(
         TypeBuilder::<CountUp>::new("CountUp")
-            .add_static("new", CountUp::with_step)
+            .add_static("with_step", CountUp::with_step)
             .add_static("new", CountUp::new)
             .add_builtin_trait_function(iterator::HasNext, CountUp::has_next)
             .add_builtin_trait_function(iterator::Next, CountUp::next),
     )?;
+    engine.add_function("countup", CountUp::new)?;
 
     engine.add_type(
         TypeBuilder::<CountDown>::new("CountDown")
-            .add_static("new", CountDown::with_step)
+            .add_static("with_step", CountDown::with_step)
             .add_static("new", CountDown::new)
             .add_builtin_trait_function(iterator::HasNext, CountDown::has_next)
             .add_builtin_trait_function(iterator::Next, CountDown::next),
     )?;
-
-    engine.start("mstd-counters.mi", include_str!("counters.mi"))?.trampoline()?;
+    engine.add_function("countdown", CountDown::new)?;
 
     Ok(())
 }

--- a/src/corelib/iterators/list.rs
+++ b/src/corelib/iterators/list.rs
@@ -1,0 +1,60 @@
+use crate::{builtin_traits::iterator, ll::value::RawValue, Engine, Error, TypeBuilder, UserData};
+
+pub(crate) struct ListIter {
+    list: RawValue,
+    i: usize,
+    len: usize,
+}
+
+impl ListIter {
+    pub(crate) unsafe fn new(list: RawValue) -> Self {
+        let slice = unsafe { list.get_raw_list_unchecked().get().as_slice() };
+        ListIter { list, i: 0, len: slice.len() }
+    }
+
+    fn has_next(&self) -> bool {
+        self.i < self.len
+    }
+
+    fn next(&mut self) -> Result<RawValue, LenChangedDuringIteration> {
+        unsafe {
+            let list = self.list.get_raw_list_unchecked().get();
+            let slice = list.as_slice();
+            if slice.len() != self.len {
+                return Err(LenChangedDuringIteration { was: self.len, became: slice.len() });
+            }
+            let i = self.i;
+            self.i += 1;
+            Ok(slice[i])
+        }
+    }
+}
+
+impl UserData for ListIter {
+    fn visit_references(&self, visit: &mut dyn FnMut(RawValue)) {
+        visit(self.list);
+    }
+}
+
+#[derive(Debug)]
+struct LenChangedDuringIteration {
+    was: usize,
+    became: usize,
+}
+
+impl std::fmt::Display for LenChangedDuringIteration {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "list length changed during iteration (was {}, became {})", self.was, self.became)
+    }
+}
+
+impl std::error::Error for LenChangedDuringIteration {}
+
+pub(crate) fn load_list_iter(engine: &mut Engine) -> Result<(), Error> {
+    engine.add_type(
+        TypeBuilder::<ListIter>::new("ListIter")
+            .add_builtin_trait_function(iterator::HasNext, ListIter::has_next)
+            .add_builtin_trait_function(iterator::Next, ListIter::next),
+    )?;
+    Ok(())
+}

--- a/src/hl/value.rs
+++ b/src/hl/value.rs
@@ -483,6 +483,7 @@ where
 {
     fn try_from_value(value: &Value, env: &Environment) -> Result<Self, Error> {
         if let Value::UserData(u) = value {
+            let u: &dyn value::UserData = (**u).as_ref();
             if let Some(object) = u.as_any().downcast_ref::<Object<T>>() {
                 let (object, _guard) = unsafe { object.unsafe_borrow()? };
                 return Ok(object.clone());

--- a/src/ll/gc.rs
+++ b/src/ll/gc.rs
@@ -209,7 +209,6 @@ impl Memory {
                         self.mark_dtable_reachable_rec(raw.get().dtable);
                     }
                 }
-                // TODO: Allow user data to specify its own references.
                 ValueKind::UserData => {
                     let raw = value.get_raw_user_data_unchecked();
                     if !raw.get_mem().reachable.get() {
@@ -217,6 +216,9 @@ impl Memory {
                     }
                     let dtable = raw.get().dtable_gcraw();
                     self.mark_dtable_reachable_rec(dtable);
+                    raw.get().visit_references(&mut |value| {
+                        self.gray_stack.push(value);
+                    });
                 }
             }
         }

--- a/src/ll/value.rs
+++ b/src/ll/value.rs
@@ -460,6 +460,7 @@ pub trait UserData: Any {
         self.dtable_gcraw().get()
     }
 
-    /// Converts a reference to `UserData` to `Any`.
+    fn visit_references(&self, _visit: &mut dyn FnMut(RawValue)) {}
+
     fn as_any(&self) -> &dyn Any;
 }

--- a/tests/stdlib/list/iter-modify-len.test.mi
+++ b/tests/stdlib/list/iter-modify-len.test.mi
@@ -1,0 +1,10 @@
+# Tests that list length cannot be modified while iterating.
+# @error error: list length changed during iteration (was 3, became 4)
+# @error stack traceback (most recent call first):
+# @error     <FFI>                        ListIter.next
+# @error     {file}:{:LINE}:1  <main>
+
+li = [1, 2, 3]
+for _ in li.iter do  # @line LINE
+    li.push(1)
+end

--- a/tests/stdlib/list/iter.test.mi
+++ b/tests/stdlib/list/iter.test.mi
@@ -1,0 +1,7 @@
+# Tests that lists can be iterated with iterators.
+
+new = []
+for x in [1, 2, 3].iter do
+    new.push(x)
+end
+assert(new == [1, 2, 3])


### PR DESCRIPTION
Introduce the ability to iterate lists using a dedicated iterator.
```
for i in [1, 2, 3].iter do
    print("iterating: ", i)
end
```

It's now also possible to make `RawValue`s inside of user data visible to the GC, so that they are marked reachable.
