### PR TITLE
String iterators

### DIFF
--- a/src/corelib/iterators.rs
+++ b/src/corelib/iterators.rs
@@ -3,17 +3,22 @@
 // moment.)
 #![allow(unreachable_pub)]
 
-use self::{counters::load_counters, dict::load_dict_iter, list::load_list_iter};
+use self::{
+    counters::load_counters, dict::load_dict_iter, list::load_list_iter,
+    string::load_string_iterators,
+};
 use crate::{Engine, Error};
 
 mod counters;
 pub mod dict;
 pub mod list;
+pub mod string;
 
 pub(crate) fn load_iterators(engine: &mut Engine) -> Result<(), Error> {
     load_counters(engine)?;
     load_list_iter(engine)?;
     load_dict_iter(engine)?;
+    load_string_iterators(engine)?;
 
     Ok(())
 }

--- a/src/corelib/iterators/string.rs
+++ b/src/corelib/iterators/string.rs
@@ -1,0 +1,24 @@
+use self::{
+    bytes::load_string_bytes_iter, chars::load_string_chars_iter,
+    code_points::load_string_code_points_iter, lines::load_string_lines_iter,
+    rsplit::load_string_rsplit_iter, split::load_string_split_iter,
+};
+use crate::{Engine, Error};
+
+pub mod bytes;
+pub mod chars;
+pub mod code_points;
+pub mod lines;
+pub mod rsplit;
+pub mod split;
+
+pub(crate) fn load_string_iterators(engine: &mut Engine) -> Result<(), Error> {
+    load_string_bytes_iter(engine)?;
+    load_string_chars_iter(engine)?;
+    load_string_code_points_iter(engine)?;
+    load_string_lines_iter(engine)?;
+    load_string_split_iter(engine)?;
+    load_string_rsplit_iter(engine)?;
+
+    Ok(())
+}

--- a/src/corelib/iterators/string/bytes.rs
+++ b/src/corelib/iterators/string/bytes.rs
@@ -1,0 +1,37 @@
+use crate::{builtin_traits::iterator, ll::value::RawValue, Engine, Error, TypeBuilder, UserData};
+
+pub(crate) struct StringBytes {
+    string: RawValue,
+    index: usize,
+}
+
+impl StringBytes {
+    pub unsafe fn new(s: RawValue) -> Self {
+        Self { string: s, index: 0 }
+    }
+
+    fn has_next(&self) -> bool {
+        self.index < unsafe { self.string.get_raw_string_unchecked().get().len() }
+    }
+
+    fn next(&mut self) -> Option<u8> {
+        unsafe {
+            let s = self.string.get_raw_string_unchecked().get().as_bytes();
+            let byte = s.get(self.index).copied();
+            self.index += 1;
+            byte
+        }
+    }
+}
+
+impl UserData for StringBytes {}
+
+pub(crate) fn load_string_bytes_iter(engine: &mut Engine) -> Result<(), Error> {
+    engine.add_type(
+        TypeBuilder::<StringBytes>::new("StringBytes")
+            .add_builtin_trait_function(iterator::HasNext, StringBytes::has_next)
+            .add_builtin_trait_function(iterator::Next, StringBytes::next),
+    )?;
+
+    Ok(())
+}

--- a/src/corelib/iterators/string/chars.rs
+++ b/src/corelib/iterators/string/chars.rs
@@ -1,0 +1,39 @@
+use crate::{builtin_traits::iterator, ll::value::RawValue, Engine, Error, TypeBuilder, UserData};
+
+pub(crate) struct StringChars {
+    string: RawValue,
+    index: usize,
+}
+
+impl StringChars {
+    pub unsafe fn new(s: RawValue) -> Self {
+        Self { string: s, index: 0 }
+    }
+
+    fn has_next(&self) -> bool {
+        self.index < unsafe { self.string.get_raw_string_unchecked().get().len() }
+    }
+
+    fn next(&mut self) -> Option<char> {
+        unsafe {
+            let s = self.string.get_raw_string_unchecked().get();
+            let ch = s[self.index..].chars().next();
+            if let Some(ch) = ch {
+                self.index += ch.len_utf8();
+            }
+            ch
+        }
+    }
+}
+
+impl UserData for StringChars {}
+
+pub(crate) fn load_string_chars_iter(engine: &mut Engine) -> Result<(), Error> {
+    engine.add_type(
+        TypeBuilder::<StringChars>::new("StringChars")
+            .add_builtin_trait_function(iterator::HasNext, StringChars::has_next)
+            .add_builtin_trait_function(iterator::Next, StringChars::next),
+    )?;
+
+    Ok(())
+}

--- a/src/corelib/iterators/string/code_points.rs
+++ b/src/corelib/iterators/string/code_points.rs
@@ -1,0 +1,39 @@
+use crate::{builtin_traits::iterator, ll::value::RawValue, Engine, Error, TypeBuilder, UserData};
+
+pub(crate) struct StringCodePoints {
+    string: RawValue,
+    index: usize,
+}
+
+impl StringCodePoints {
+    pub unsafe fn new(s: RawValue) -> Self {
+        Self { string: s, index: 0 }
+    }
+
+    fn has_next(&self) -> bool {
+        self.index < unsafe { self.string.get_raw_string_unchecked().get().len() }
+    }
+
+    fn next(&mut self) -> Option<u32> {
+        unsafe {
+            let s = self.string.get_raw_string_unchecked().get();
+            let ch = s[self.index..].chars().next();
+            if let Some(ch) = ch {
+                self.index += ch.len_utf8();
+            }
+            ch.map(u32::from)
+        }
+    }
+}
+
+impl UserData for StringCodePoints {}
+
+pub(crate) fn load_string_code_points_iter(engine: &mut Engine) -> Result<(), Error> {
+    engine.add_type(
+        TypeBuilder::<StringCodePoints>::new("StringCodePoints")
+            .add_builtin_trait_function(iterator::HasNext, StringCodePoints::has_next)
+            .add_builtin_trait_function(iterator::Next, StringCodePoints::next),
+    )?;
+
+    Ok(())
+}

--- a/src/corelib/iterators/string/lines.rs
+++ b/src/corelib/iterators/string/lines.rs
@@ -1,0 +1,46 @@
+use crate::{builtin_traits::iterator, ll::value::RawValue, Engine, Error, TypeBuilder, UserData};
+
+pub(crate) struct StringLines {
+    string: RawValue,
+    index: usize,
+}
+
+impl StringLines {
+    pub unsafe fn new(s: RawValue) -> Self {
+        Self { string: s, index: 0 }
+    }
+
+    fn has_next(&self) -> bool {
+        self.index < unsafe { self.string.get_raw_string_unchecked().get().len() }
+    }
+
+    fn next(&mut self) -> Option<String> {
+        unsafe {
+            let s = self.string.get_raw_string_unchecked().get();
+            let line = s[self.index..].lines().next();
+            if let Some(line) = line {
+                self.index += line.len();
+            }
+            // Since the resulting string does not count in the line separator, we have to handle
+            // it ourselves here.
+            if s[self.index..].starts_with("\r\n") {
+                self.index += 2;
+            } else if s[self.index..].starts_with('\n') {
+                self.index += 1;
+            }
+            line.map(String::from)
+        }
+    }
+}
+
+impl UserData for StringLines {}
+
+pub(crate) fn load_string_lines_iter(engine: &mut Engine) -> Result<(), Error> {
+    engine.add_type(
+        TypeBuilder::<StringLines>::new("StringLines")
+            .add_builtin_trait_function(iterator::HasNext, StringLines::has_next)
+            .add_builtin_trait_function(iterator::Next, StringLines::next),
+    )?;
+
+    Ok(())
+}

--- a/src/corelib/iterators/string/rsplit.rs
+++ b/src/corelib/iterators/string/rsplit.rs
@@ -1,0 +1,43 @@
+use crate::{
+    builtin_traits::iterator, ll::value::RawValue, Engine, Error, Gc, TypeBuilder, UserData,
+};
+
+pub(crate) struct StringRSplit {
+    string: RawValue,
+    separator: Gc<String>,
+    index: usize,
+}
+
+impl StringRSplit {
+    pub unsafe fn new(s: RawValue, separator: Gc<String>) -> Self {
+        Self { string: s, separator, index: unsafe { s.get_raw_string_unchecked().get().len() } }
+    }
+
+    fn has_next(&self) -> bool {
+        self.index != 0
+    }
+
+    fn next(&mut self) -> Option<String> {
+        unsafe {
+            let s = self.string.get_raw_string_unchecked().get();
+            let fragment = s[0..self.index].rsplit(&**self.separator).next();
+            if let Some(fragment) = fragment {
+                self.index -= fragment.len();
+                self.index = self.index.saturating_sub(self.separator.len());
+            }
+            fragment.map(String::from)
+        }
+    }
+}
+
+impl UserData for StringRSplit {}
+
+pub(crate) fn load_string_rsplit_iter(engine: &mut Engine) -> Result<(), Error> {
+    engine.add_type(
+        TypeBuilder::<StringRSplit>::new("StringRSplit")
+            .add_builtin_trait_function(iterator::HasNext, StringRSplit::has_next)
+            .add_builtin_trait_function(iterator::Next, StringRSplit::next),
+    )?;
+
+    Ok(())
+}

--- a/src/corelib/iterators/string/split.rs
+++ b/src/corelib/iterators/string/split.rs
@@ -1,0 +1,43 @@
+use crate::{
+    builtin_traits::iterator, ll::value::RawValue, Engine, Error, Gc, TypeBuilder, UserData,
+};
+
+pub(crate) struct StringSplit {
+    string: RawValue,
+    separator: Gc<String>,
+    index: usize,
+}
+
+impl StringSplit {
+    pub unsafe fn new(s: RawValue, separator: Gc<String>) -> Self {
+        Self { string: s, separator, index: 0 }
+    }
+
+    fn has_next(&self) -> bool {
+        self.index < unsafe { self.string.get_raw_string_unchecked().get().len() }
+    }
+
+    fn next(&mut self) -> Option<String> {
+        unsafe {
+            let s = self.string.get_raw_string_unchecked().get();
+            let fragment = s[self.index..].split(&**self.separator).next();
+            if let Some(fragment) = fragment {
+                self.index += fragment.len();
+                self.index += self.separator.len();
+            }
+            fragment.map(String::from)
+        }
+    }
+}
+
+impl UserData for StringSplit {}
+
+pub(crate) fn load_string_split_iter(engine: &mut Engine) -> Result<(), Error> {
+    engine.add_type(
+        TypeBuilder::<StringSplit>::new("StringSplit")
+            .add_builtin_trait_function(iterator::HasNext, StringSplit::has_next)
+            .add_builtin_trait_function(iterator::Next, StringSplit::next),
+    )?;
+
+    Ok(())
+}

--- a/tests/stdlib/string/iter-bytes.test.mi
+++ b/tests/stdlib/string/iter-bytes.test.mi
@@ -1,0 +1,7 @@
+# Tests the string bytes iterator.
+
+bytes = []
+for b in "cześć".bytes do
+    bytes.push(b)
+end
+assert(bytes == [\u'c', \u'z', \u'e', \xC5, \x9B, \xC4, \x87])

--- a/tests/stdlib/string/iter-chars.test.mi
+++ b/tests/stdlib/string/iter-chars.test.mi
@@ -1,0 +1,7 @@
+# Tests the string chars iterator.
+
+chars = []
+for c in "cześć".chars do
+    chars.push(c)
+end
+assert(chars == ["c", "z", "e", "ś", "ć"])

--- a/tests/stdlib/string/iter-code-points.test.mi
+++ b/tests/stdlib/string/iter-code-points.test.mi
@@ -1,0 +1,7 @@
+# Tests the string code_points iterator.
+
+chars = []
+for c in "cześć".code_points do
+    chars.push(c)
+end
+assert(chars == [\u'c', \u'z', \u'e', \u'ś', \u'ć'])

--- a/tests/stdlib/string/iter-lines.test.mi
+++ b/tests/stdlib/string/iter-lines.test.mi
@@ -1,0 +1,13 @@
+# Tests the string lines iterator.
+
+text =
+    \\Hello
+    \\world!
+    \\
+    \\That was a blank.
+
+lines = []
+for line in text.lines do
+    lines.push(line)
+end
+assert(lines == ["Hello", "world!", "", "That was a blank."])

--- a/tests/stdlib/string/iter-rsplit.test.mi
+++ b/tests/stdlib/string/iter-rsplit.test.mi
@@ -1,0 +1,7 @@
+# Tests the string rsplit iterator.
+
+fragments = []
+for fragment in "example,hello,world".rsplit(",") do
+    fragments.push(fragment)
+end
+assert(fragments == ["world", "hello", "example"])

--- a/tests/stdlib/string/iter-split.test.mi
+++ b/tests/stdlib/string/iter-split.test.mi
@@ -1,0 +1,7 @@
+# Tests the string split iterator.
+
+fragments = []
+for fragment in "example,hello,world".split(",") do
+    fragments.push(fragment)
+end
+assert(fragments == ["example", "hello", "world"])


### PR DESCRIPTION
Continuing the long journey of implementing the core library, this PR introduces string iterators:
- `bytes/0`
- `chars/0`
- `code_points/0`
- `lines/0`
- `split/1`
- `rsplit/1`