### PR TITLE
Separate dtables out into a Library component

### DIFF
--- a/src/corelib/builtins/dict.rs
+++ b/src/corelib/builtins/dict.rs
@@ -16,10 +16,10 @@ pub(crate) fn define(builder: TypeBuilder<Dict>) -> TypeBuilder<Dict> {
         .add_raw_function(
             "iter",
             MethodParameterCount::from_count_with_self(1),
-            RawFunctionKind::Foreign(Box::new(|env, gc, args| {
-                let arguments = Arguments::new(args, env);
+            RawFunctionKind::Foreign(Box::new(|library, gc, args| {
+                let arguments = Arguments::new(args, library);
                 let iter = unsafe { DictIter::new(*arguments.raw_self()) };
-                Ok(iter.into_value_with_environment(env).to_raw(gc))
+                Ok(iter.into_value_with_library(library).to_raw(gc))
             })),
         )
 }

--- a/src/corelib/builtins/list.rs
+++ b/src/corelib/builtins/list.rs
@@ -52,10 +52,10 @@ pub(crate) fn define(builder: TypeBuilder<Vec<RawValue>>) -> TypeBuilder<Vec<Raw
         .add_raw_function(
             "iter",
             MethodParameterCount::from_count_with_self(1),
-            RawFunctionKind::Foreign(Box::new(|env, gc, args| {
-                let arguments = Arguments::new(args, env);
+            RawFunctionKind::Foreign(Box::new(|library, gc, args| {
+                let arguments = Arguments::new(args, library);
                 let iter = unsafe { ListIter::new(*arguments.raw_self()) };
-                Ok(iter.into_value_with_environment(env).to_raw(gc))
+                Ok(iter.into_value_with_library(library).to_raw(gc))
             })),
         )
 }

--- a/src/corelib/builtins/string.rs
+++ b/src/corelib/builtins/string.rs
@@ -51,57 +51,57 @@ pub(crate) fn define(builder: TypeBuilder<String>) -> TypeBuilder<String> {
         .add_raw_function(
             "bytes",
             MethodParameterCount::from_count_with_self(1),
-            RawFunctionKind::Foreign(Box::new(|env, gc, args| {
-                let arguments = Arguments::new(args, env);
+            RawFunctionKind::Foreign(Box::new(|library, gc, args| {
+                let arguments = Arguments::new(args, library);
                 let iter = unsafe { StringBytes::new(*arguments.raw_self()) };
-                Ok(iter.into_value_with_environment(env).to_raw(gc))
+                Ok(iter.into_value_with_library(library).to_raw(gc))
             })),
         )
         .add_raw_function(
             "chars",
             MethodParameterCount::from_count_with_self(1),
-            RawFunctionKind::Foreign(Box::new(|env, gc, args| {
-                let arguments = Arguments::new(args, env);
+            RawFunctionKind::Foreign(Box::new(|library, gc, args| {
+                let arguments = Arguments::new(args, library);
                 let iter = unsafe { StringChars::new(*arguments.raw_self()) };
-                Ok(iter.into_value_with_environment(env).to_raw(gc))
+                Ok(iter.into_value_with_library(library).to_raw(gc))
             })),
         )
         .add_raw_function(
             "code_points",
             MethodParameterCount::from_count_with_self(1),
-            RawFunctionKind::Foreign(Box::new(|env, gc, args| {
-                let arguments = Arguments::new(args, env);
+            RawFunctionKind::Foreign(Box::new(|library, gc, args| {
+                let arguments = Arguments::new(args, library);
                 let iter = unsafe { StringCodePoints::new(*arguments.raw_self()) };
-                Ok(iter.into_value_with_environment(env).to_raw(gc))
+                Ok(iter.into_value_with_library(library).to_raw(gc))
             })),
         )
         .add_raw_function(
             "lines",
             MethodParameterCount::from_count_with_self(1),
-            RawFunctionKind::Foreign(Box::new(|env, gc, args| {
-                let arguments = Arguments::new(args, env);
+            RawFunctionKind::Foreign(Box::new(|library, gc, args| {
+                let arguments = Arguments::new(args, library);
                 let iter = unsafe { StringLines::new(*arguments.raw_self()) };
-                Ok(iter.into_value_with_environment(env).to_raw(gc))
+                Ok(iter.into_value_with_library(library).to_raw(gc))
             })),
         )
         .add_raw_function(
             "split",
             MethodParameterCount::from_count_with_self(2),
-            RawFunctionKind::Foreign(Box::new(|env, gc, args| {
-                let arguments = Arguments::new(args, env);
+            RawFunctionKind::Foreign(Box::new(|library, gc, args| {
+                let arguments = Arguments::new(args, library);
                 let sep: Gc<String> = arguments.get(0).to_language_error()?;
                 let iter = unsafe { StringSplit::new(*arguments.raw_self(), sep) };
-                Ok(iter.into_value_with_environment(env).to_raw(gc))
+                Ok(iter.into_value_with_library(library).to_raw(gc))
             })),
         )
         .add_raw_function(
             "rsplit",
             MethodParameterCount::from_count_with_self(2),
-            RawFunctionKind::Foreign(Box::new(|env, gc, args| {
-                let arguments = Arguments::new(args, env);
+            RawFunctionKind::Foreign(Box::new(|library, gc, args| {
+                let arguments = Arguments::new(args, library);
                 let sep: Gc<String> = arguments.get(0).to_language_error()?;
                 let iter = unsafe { StringRSplit::new(*arguments.raw_self(), sep) };
-                Ok(iter.into_value_with_environment(env).to_raw(gc))
+                Ok(iter.into_value_with_library(library).to_raw(gc))
             })),
         )
 }

--- a/src/hl/fiber.rs
+++ b/src/hl/fiber.rs
@@ -17,9 +17,9 @@ impl<'e> Fiber<'e> {
         if self.inner.halted() {
             Ok(None)
         } else {
-            let Engine { env, globals, gc, .. } = &mut self.engine;
-            let result = self.inner.interpret(env, globals, gc)?;
-            Ok(Some(T::try_from_value(&Value::from_raw(result), &self.engine.env)?))
+            let Engine { env, library, globals, gc, .. } = &mut self.engine;
+            let result = self.inner.interpret(env, library, globals, gc)?;
+            Ok(Some(T::try_from_value(&Value::from_raw(result), &self.engine.library)?))
         }
     }
 
@@ -35,7 +35,7 @@ impl<'e> Fiber<'e> {
         while let Some(v) = self.resume()? {
             result = v;
         }
-        T::try_from_value(&result, &self.engine.env)
+        T::try_from_value(&result, &self.engine.library)
     }
 }
 

--- a/src/hl/function.rs
+++ b/src/hl/function.rs
@@ -1,14 +1,8 @@
 pub use crate::ll::bytecode::{FunctionParameterCount, MethodParameterCount};
 use crate::{
-    ll::{bytecode::Environment, gc::Memory, value::RawValue},
+    ll::{bytecode::Library, value::RawValue},
     Error, IntoValue, LanguageErrorKind, RawForeignFunction, TryFromValue, Value,
 };
-
-fn create_rawff(
-    f: impl Fn(&Environment, &mut Memory, &[RawValue]) -> Result<RawValue, LanguageErrorKind> + 'static,
-) -> RawForeignFunction {
-    Box::new(f)
-}
 
 /// Arguments passed to a varargs function.
 ///
@@ -17,15 +11,15 @@ fn create_rawff(
 pub struct Arguments<'a> {
     this: RawValue,
     inner: &'a [RawValue],
-    env: &'a Environment,
+    library: &'a Library,
 }
 
 impl<'a> Arguments<'a> {
     /// Creates a new [`Arguments`] from a raw argument list, as is passed into a
     /// [raw function][RawForeignFunction].
-    pub fn new(raw_arguments: &'a [RawValue], env: &'a Environment) -> Self {
+    pub fn new(raw_arguments: &'a [RawValue], library: &'a Library) -> Self {
         // Skip the first argument, which is `self` (or the currently called function).
-        Self { this: raw_arguments[0], inner: &raw_arguments[1..], env }
+        Self { this: raw_arguments[0], inner: &raw_arguments[1..], library }
     }
 
     /// Returns the number of arguments passed to the function.
@@ -68,7 +62,7 @@ impl<'a> Arguments<'a> {
         T: TryFromValue,
     {
         let value = self.inner.get(n).cloned().unwrap_or(RawValue::from(()));
-        T::try_from_value(&Value::from_raw(value), self.env).map_err(|error| {
+        T::try_from_value(&Value::from_raw(value), self.library).map_err(|error| {
             if let Error::TypeMismatch { expected, got } = error {
                 Error::ArgumentTypeMismatch { index: n, expected, got }
             } else {
@@ -272,9 +266,9 @@ where
     const PARAMETER_COUNT: Self::ParameterCount = FunctionParameterCount::Varargs;
 
     fn into_raw_foreign_function(self) -> RawForeignFunction {
-        create_rawff(move |env, gc, args| {
-            self(Arguments::new(args, env))
-                .map(|value| value.into_value_with_environment(env).to_raw(gc))
+        Box::new(move |library, gc, args| {
+            self(Arguments::new(args, library))
+                .map(|value| value.into_value_with_library(library).to_raw(gc))
                 .map_err(|error| LanguageErrorKind::User(Box::new(error)))
         })
     }
@@ -290,8 +284,8 @@ where
     const PARAMETER_COUNT: Self::ParameterCount = FunctionParameterCount::Varargs;
 
     fn into_raw_foreign_function(self) -> RawForeignFunction {
-        create_rawff(move |env, gc, args| {
-            Ok(self(Arguments::new(args, env)).into_value_with_environment(env).to_raw(gc))
+        Box::new(move |library, gc, args| {
+            Ok(self(Arguments::new(args, library)).into_value_with_library(library).to_raw(gc))
         })
     }
 }

--- a/src/hl/generated/function_variants.rs
+++ b/src/hl/generated/function_variants.rs
@@ -20,11 +20,11 @@ where
     const PARAMETER_COUNT: Self::ParameterCount = Self::ParameterCount::Fixed(0);
 
     fn into_raw_foreign_function(self) -> RawForeignFunction {
-        Box::new(move |env, gc, args| {
-            let arguments = Arguments::new(args, env);
+        Box::new(move |library, gc, args| {
+            let arguments = Arguments::new(args, library);
             let result = self();
 
-            Ok(result.into_value_with_environment(env).to_raw(gc))
+            Ok(result.into_value_with_library(library).to_raw(gc))
         })
     }
 }
@@ -39,11 +39,11 @@ where
     const PARAMETER_COUNT: Self::ParameterCount = Self::ParameterCount::Fixed(0);
 
     fn into_raw_foreign_function(self) -> RawForeignFunction {
-        Box::new(move |env, gc, args| {
-            let arguments = Arguments::new(args, env);
+        Box::new(move |library, gc, args| {
+            let arguments = Arguments::new(args, library);
             let result = self();
 
-            wrap_in_language_error(result.map(|v| v.into_value_with_environment(env).to_raw(gc)))
+            wrap_in_language_error(result.map(|v| v.into_value_with_library(library).to_raw(gc)))
         })
     }
 }
@@ -57,13 +57,13 @@ where
     const PARAMETER_COUNT: Self::ParameterCount = Self::ParameterCount::from_count_with_self(1);
 
     fn into_raw_foreign_function(self) -> RawForeignFunction {
-        Box::new(move |env, gc, args| {
-            let arguments = Arguments::new(args, env);
+        Box::new(move |library, gc, args| {
+            let arguments = Arguments::new(args, library);
             let arg_self = RawSelf(arguments.raw_self());
 
             let result = self(arg_self);
 
-            Ok(result.into_value_with_environment(env).to_raw(gc))
+            Ok(result.into_value_with_library(library).to_raw(gc))
         })
     }
 }
@@ -78,13 +78,13 @@ where
     const PARAMETER_COUNT: Self::ParameterCount = Self::ParameterCount::from_count_with_self(1);
 
     fn into_raw_foreign_function(self) -> RawForeignFunction {
-        Box::new(move |env, gc, args| {
-            let arguments = Arguments::new(args, env);
+        Box::new(move |library, gc, args| {
+            let arguments = Arguments::new(args, library);
             let arg_self = RawSelf(arguments.raw_self());
 
             let result = self(arg_self);
 
-            wrap_in_language_error(result.map(|v| v.into_value_with_environment(env).to_raw(gc)))
+            wrap_in_language_error(result.map(|v| v.into_value_with_library(library).to_raw(gc)))
         })
     }
 }
@@ -100,15 +100,15 @@ where
     const PARAMETER_COUNT: Self::ParameterCount = Self::ParameterCount::from_count_with_self(1);
 
     fn into_raw_foreign_function(self) -> RawForeignFunction {
-        Box::new(move |env, gc, args| {
-            let arguments = Arguments::new(args, env);
+        Box::new(move |library, gc, args| {
+            let arguments = Arguments::new(args, library);
             let (arg_self, _guard) = wrap_in_language_error(unsafe {
                 <Recv as SelfFromRawValue>::self_from_raw_value(arguments.raw_self())
             })?;
 
             let result = self(arg_self);
 
-            Ok(result.into_value_with_environment(env).to_raw(gc))
+            Ok(result.into_value_with_library(library).to_raw(gc))
         })
     }
 }
@@ -124,15 +124,15 @@ where
     const PARAMETER_COUNT: Self::ParameterCount = Self::ParameterCount::from_count_with_self(1);
 
     fn into_raw_foreign_function(self) -> RawForeignFunction {
-        Box::new(move |env, gc, args| {
-            let arguments = Arguments::new(args, env);
+        Box::new(move |library, gc, args| {
+            let arguments = Arguments::new(args, library);
             let (arg_self, _guard) = wrap_in_language_error(unsafe {
                 <Recv as MutSelfFromRawValue>::mut_self_from_raw_value(arguments.raw_self())
             })?;
 
             let result = self(arg_self);
 
-            Ok(result.into_value_with_environment(env).to_raw(gc))
+            Ok(result.into_value_with_library(library).to_raw(gc))
         })
     }
 }
@@ -149,15 +149,15 @@ where
     const PARAMETER_COUNT: Self::ParameterCount = Self::ParameterCount::from_count_with_self(1);
 
     fn into_raw_foreign_function(self) -> RawForeignFunction {
-        Box::new(move |env, gc, args| {
-            let arguments = Arguments::new(args, env);
+        Box::new(move |library, gc, args| {
+            let arguments = Arguments::new(args, library);
             let (arg_self, _guard) = wrap_in_language_error(unsafe {
                 <Recv as SelfFromRawValue>::self_from_raw_value(arguments.raw_self())
             })?;
 
             let result = self(arg_self);
 
-            wrap_in_language_error(result.map(|v| v.into_value_with_environment(env).to_raw(gc)))
+            wrap_in_language_error(result.map(|v| v.into_value_with_library(library).to_raw(gc)))
         })
     }
 }
@@ -174,15 +174,15 @@ where
     const PARAMETER_COUNT: Self::ParameterCount = Self::ParameterCount::from_count_with_self(1);
 
     fn into_raw_foreign_function(self) -> RawForeignFunction {
-        Box::new(move |env, gc, args| {
-            let arguments = Arguments::new(args, env);
+        Box::new(move |library, gc, args| {
+            let arguments = Arguments::new(args, library);
             let (arg_self, _guard) = wrap_in_language_error(unsafe {
                 <Recv as MutSelfFromRawValue>::mut_self_from_raw_value(arguments.raw_self())
             })?;
 
             let result = self(arg_self);
 
-            wrap_in_language_error(result.map(|v| v.into_value_with_environment(env).to_raw(gc)))
+            wrap_in_language_error(result.map(|v| v.into_value_with_library(library).to_raw(gc)))
         })
     }
 }
@@ -197,13 +197,13 @@ where
     const PARAMETER_COUNT: Self::ParameterCount = Self::ParameterCount::Fixed(1);
 
     fn into_raw_foreign_function(self) -> RawForeignFunction {
-        Box::new(move |env, gc, args| {
-            let arguments = Arguments::new(args, env);
+        Box::new(move |library, gc, args| {
+            let arguments = Arguments::new(args, library);
             let arg_0 = wrap_in_language_error(arguments.get(0))?;
 
             let result = self(arg_0);
 
-            Ok(result.into_value_with_environment(env).to_raw(gc))
+            Ok(result.into_value_with_library(library).to_raw(gc))
         })
     }
 }
@@ -219,13 +219,13 @@ where
     const PARAMETER_COUNT: Self::ParameterCount = Self::ParameterCount::Fixed(1);
 
     fn into_raw_foreign_function(self) -> RawForeignFunction {
-        Box::new(move |env, gc, args| {
-            let arguments = Arguments::new(args, env);
+        Box::new(move |library, gc, args| {
+            let arguments = Arguments::new(args, library);
             let arg_0 = wrap_in_language_error(arguments.get(0))?;
 
             let result = self(arg_0);
 
-            wrap_in_language_error(result.map(|v| v.into_value_with_environment(env).to_raw(gc)))
+            wrap_in_language_error(result.map(|v| v.into_value_with_library(library).to_raw(gc)))
         })
     }
 }
@@ -240,14 +240,14 @@ where
     const PARAMETER_COUNT: Self::ParameterCount = Self::ParameterCount::from_count_with_self(2);
 
     fn into_raw_foreign_function(self) -> RawForeignFunction {
-        Box::new(move |env, gc, args| {
-            let arguments = Arguments::new(args, env);
+        Box::new(move |library, gc, args| {
+            let arguments = Arguments::new(args, library);
             let arg_self = RawSelf(arguments.raw_self());
             let arg_0 = wrap_in_language_error(arguments.get(0))?;
 
             let result = self(arg_self, arg_0);
 
-            Ok(result.into_value_with_environment(env).to_raw(gc))
+            Ok(result.into_value_with_library(library).to_raw(gc))
         })
     }
 }
@@ -263,14 +263,14 @@ where
     const PARAMETER_COUNT: Self::ParameterCount = Self::ParameterCount::from_count_with_self(2);
 
     fn into_raw_foreign_function(self) -> RawForeignFunction {
-        Box::new(move |env, gc, args| {
-            let arguments = Arguments::new(args, env);
+        Box::new(move |library, gc, args| {
+            let arguments = Arguments::new(args, library);
             let arg_self = RawSelf(arguments.raw_self());
             let arg_0 = wrap_in_language_error(arguments.get(0))?;
 
             let result = self(arg_self, arg_0);
 
-            wrap_in_language_error(result.map(|v| v.into_value_with_environment(env).to_raw(gc)))
+            wrap_in_language_error(result.map(|v| v.into_value_with_library(library).to_raw(gc)))
         })
     }
 }
@@ -287,8 +287,8 @@ where
     const PARAMETER_COUNT: Self::ParameterCount = Self::ParameterCount::from_count_with_self(2);
 
     fn into_raw_foreign_function(self) -> RawForeignFunction {
-        Box::new(move |env, gc, args| {
-            let arguments = Arguments::new(args, env);
+        Box::new(move |library, gc, args| {
+            let arguments = Arguments::new(args, library);
             let (arg_self, _guard) = wrap_in_language_error(unsafe {
                 <Recv as SelfFromRawValue>::self_from_raw_value(arguments.raw_self())
             })?;
@@ -296,7 +296,7 @@ where
 
             let result = self(arg_self, arg_0);
 
-            Ok(result.into_value_with_environment(env).to_raw(gc))
+            Ok(result.into_value_with_library(library).to_raw(gc))
         })
     }
 }
@@ -314,8 +314,8 @@ where
     const PARAMETER_COUNT: Self::ParameterCount = Self::ParameterCount::from_count_with_self(2);
 
     fn into_raw_foreign_function(self) -> RawForeignFunction {
-        Box::new(move |env, gc, args| {
-            let arguments = Arguments::new(args, env);
+        Box::new(move |library, gc, args| {
+            let arguments = Arguments::new(args, library);
             let (arg_self, _guard) = wrap_in_language_error(unsafe {
                 <Recv as MutSelfFromRawValue>::mut_self_from_raw_value(arguments.raw_self())
             })?;
@@ -323,7 +323,7 @@ where
 
             let result = self(arg_self, arg_0);
 
-            Ok(result.into_value_with_environment(env).to_raw(gc))
+            Ok(result.into_value_with_library(library).to_raw(gc))
         })
     }
 }
@@ -341,8 +341,8 @@ where
     const PARAMETER_COUNT: Self::ParameterCount = Self::ParameterCount::from_count_with_self(2);
 
     fn into_raw_foreign_function(self) -> RawForeignFunction {
-        Box::new(move |env, gc, args| {
-            let arguments = Arguments::new(args, env);
+        Box::new(move |library, gc, args| {
+            let arguments = Arguments::new(args, library);
             let (arg_self, _guard) = wrap_in_language_error(unsafe {
                 <Recv as SelfFromRawValue>::self_from_raw_value(arguments.raw_self())
             })?;
@@ -350,7 +350,7 @@ where
 
             let result = self(arg_self, arg_0);
 
-            wrap_in_language_error(result.map(|v| v.into_value_with_environment(env).to_raw(gc)))
+            wrap_in_language_error(result.map(|v| v.into_value_with_library(library).to_raw(gc)))
         })
     }
 }
@@ -368,8 +368,8 @@ where
     const PARAMETER_COUNT: Self::ParameterCount = Self::ParameterCount::from_count_with_self(2);
 
     fn into_raw_foreign_function(self) -> RawForeignFunction {
-        Box::new(move |env, gc, args| {
-            let arguments = Arguments::new(args, env);
+        Box::new(move |library, gc, args| {
+            let arguments = Arguments::new(args, library);
             let (arg_self, _guard) = wrap_in_language_error(unsafe {
                 <Recv as MutSelfFromRawValue>::mut_self_from_raw_value(arguments.raw_self())
             })?;
@@ -377,7 +377,7 @@ where
 
             let result = self(arg_self, arg_0);
 
-            wrap_in_language_error(result.map(|v| v.into_value_with_environment(env).to_raw(gc)))
+            wrap_in_language_error(result.map(|v| v.into_value_with_library(library).to_raw(gc)))
         })
     }
 }
@@ -393,14 +393,14 @@ where
     const PARAMETER_COUNT: Self::ParameterCount = Self::ParameterCount::Fixed(2);
 
     fn into_raw_foreign_function(self) -> RawForeignFunction {
-        Box::new(move |env, gc, args| {
-            let arguments = Arguments::new(args, env);
+        Box::new(move |library, gc, args| {
+            let arguments = Arguments::new(args, library);
             let arg_0 = wrap_in_language_error(arguments.get(0))?;
             let arg_1 = wrap_in_language_error(arguments.get(1))?;
 
             let result = self(arg_0, arg_1);
 
-            Ok(result.into_value_with_environment(env).to_raw(gc))
+            Ok(result.into_value_with_library(library).to_raw(gc))
         })
     }
 }
@@ -417,14 +417,14 @@ where
     const PARAMETER_COUNT: Self::ParameterCount = Self::ParameterCount::Fixed(2);
 
     fn into_raw_foreign_function(self) -> RawForeignFunction {
-        Box::new(move |env, gc, args| {
-            let arguments = Arguments::new(args, env);
+        Box::new(move |library, gc, args| {
+            let arguments = Arguments::new(args, library);
             let arg_0 = wrap_in_language_error(arguments.get(0))?;
             let arg_1 = wrap_in_language_error(arguments.get(1))?;
 
             let result = self(arg_0, arg_1);
 
-            wrap_in_language_error(result.map(|v| v.into_value_with_environment(env).to_raw(gc)))
+            wrap_in_language_error(result.map(|v| v.into_value_with_library(library).to_raw(gc)))
         })
     }
 }
@@ -440,15 +440,15 @@ where
     const PARAMETER_COUNT: Self::ParameterCount = Self::ParameterCount::from_count_with_self(3);
 
     fn into_raw_foreign_function(self) -> RawForeignFunction {
-        Box::new(move |env, gc, args| {
-            let arguments = Arguments::new(args, env);
+        Box::new(move |library, gc, args| {
+            let arguments = Arguments::new(args, library);
             let arg_self = RawSelf(arguments.raw_self());
             let arg_0 = wrap_in_language_error(arguments.get(0))?;
             let arg_1 = wrap_in_language_error(arguments.get(1))?;
 
             let result = self(arg_self, arg_0, arg_1);
 
-            Ok(result.into_value_with_environment(env).to_raw(gc))
+            Ok(result.into_value_with_library(library).to_raw(gc))
         })
     }
 }
@@ -465,15 +465,15 @@ where
     const PARAMETER_COUNT: Self::ParameterCount = Self::ParameterCount::from_count_with_self(3);
 
     fn into_raw_foreign_function(self) -> RawForeignFunction {
-        Box::new(move |env, gc, args| {
-            let arguments = Arguments::new(args, env);
+        Box::new(move |library, gc, args| {
+            let arguments = Arguments::new(args, library);
             let arg_self = RawSelf(arguments.raw_self());
             let arg_0 = wrap_in_language_error(arguments.get(0))?;
             let arg_1 = wrap_in_language_error(arguments.get(1))?;
 
             let result = self(arg_self, arg_0, arg_1);
 
-            wrap_in_language_error(result.map(|v| v.into_value_with_environment(env).to_raw(gc)))
+            wrap_in_language_error(result.map(|v| v.into_value_with_library(library).to_raw(gc)))
         })
     }
 }
@@ -492,8 +492,8 @@ where
     const PARAMETER_COUNT: Self::ParameterCount = Self::ParameterCount::from_count_with_self(3);
 
     fn into_raw_foreign_function(self) -> RawForeignFunction {
-        Box::new(move |env, gc, args| {
-            let arguments = Arguments::new(args, env);
+        Box::new(move |library, gc, args| {
+            let arguments = Arguments::new(args, library);
             let (arg_self, _guard) = wrap_in_language_error(unsafe {
                 <Recv as SelfFromRawValue>::self_from_raw_value(arguments.raw_self())
             })?;
@@ -502,7 +502,7 @@ where
 
             let result = self(arg_self, arg_0, arg_1);
 
-            Ok(result.into_value_with_environment(env).to_raw(gc))
+            Ok(result.into_value_with_library(library).to_raw(gc))
         })
     }
 }
@@ -521,8 +521,8 @@ where
     const PARAMETER_COUNT: Self::ParameterCount = Self::ParameterCount::from_count_with_self(3);
 
     fn into_raw_foreign_function(self) -> RawForeignFunction {
-        Box::new(move |env, gc, args| {
-            let arguments = Arguments::new(args, env);
+        Box::new(move |library, gc, args| {
+            let arguments = Arguments::new(args, library);
             let (arg_self, _guard) = wrap_in_language_error(unsafe {
                 <Recv as MutSelfFromRawValue>::mut_self_from_raw_value(arguments.raw_self())
             })?;
@@ -531,7 +531,7 @@ where
 
             let result = self(arg_self, arg_0, arg_1);
 
-            Ok(result.into_value_with_environment(env).to_raw(gc))
+            Ok(result.into_value_with_library(library).to_raw(gc))
         })
     }
 }
@@ -551,8 +551,8 @@ where
     const PARAMETER_COUNT: Self::ParameterCount = Self::ParameterCount::from_count_with_self(3);
 
     fn into_raw_foreign_function(self) -> RawForeignFunction {
-        Box::new(move |env, gc, args| {
-            let arguments = Arguments::new(args, env);
+        Box::new(move |library, gc, args| {
+            let arguments = Arguments::new(args, library);
             let (arg_self, _guard) = wrap_in_language_error(unsafe {
                 <Recv as SelfFromRawValue>::self_from_raw_value(arguments.raw_self())
             })?;
@@ -561,7 +561,7 @@ where
 
             let result = self(arg_self, arg_0, arg_1);
 
-            wrap_in_language_error(result.map(|v| v.into_value_with_environment(env).to_raw(gc)))
+            wrap_in_language_error(result.map(|v| v.into_value_with_library(library).to_raw(gc)))
         })
     }
 }
@@ -581,8 +581,8 @@ where
     const PARAMETER_COUNT: Self::ParameterCount = Self::ParameterCount::from_count_with_self(3);
 
     fn into_raw_foreign_function(self) -> RawForeignFunction {
-        Box::new(move |env, gc, args| {
-            let arguments = Arguments::new(args, env);
+        Box::new(move |library, gc, args| {
+            let arguments = Arguments::new(args, library);
             let (arg_self, _guard) = wrap_in_language_error(unsafe {
                 <Recv as MutSelfFromRawValue>::mut_self_from_raw_value(arguments.raw_self())
             })?;
@@ -591,7 +591,7 @@ where
 
             let result = self(arg_self, arg_0, arg_1);
 
-            wrap_in_language_error(result.map(|v| v.into_value_with_environment(env).to_raw(gc)))
+            wrap_in_language_error(result.map(|v| v.into_value_with_library(library).to_raw(gc)))
         })
     }
 }
@@ -608,15 +608,15 @@ where
     const PARAMETER_COUNT: Self::ParameterCount = Self::ParameterCount::Fixed(3);
 
     fn into_raw_foreign_function(self) -> RawForeignFunction {
-        Box::new(move |env, gc, args| {
-            let arguments = Arguments::new(args, env);
+        Box::new(move |library, gc, args| {
+            let arguments = Arguments::new(args, library);
             let arg_0 = wrap_in_language_error(arguments.get(0))?;
             let arg_1 = wrap_in_language_error(arguments.get(1))?;
             let arg_2 = wrap_in_language_error(arguments.get(2))?;
 
             let result = self(arg_0, arg_1, arg_2);
 
-            Ok(result.into_value_with_environment(env).to_raw(gc))
+            Ok(result.into_value_with_library(library).to_raw(gc))
         })
     }
 }
@@ -634,15 +634,15 @@ where
     const PARAMETER_COUNT: Self::ParameterCount = Self::ParameterCount::Fixed(3);
 
     fn into_raw_foreign_function(self) -> RawForeignFunction {
-        Box::new(move |env, gc, args| {
-            let arguments = Arguments::new(args, env);
+        Box::new(move |library, gc, args| {
+            let arguments = Arguments::new(args, library);
             let arg_0 = wrap_in_language_error(arguments.get(0))?;
             let arg_1 = wrap_in_language_error(arguments.get(1))?;
             let arg_2 = wrap_in_language_error(arguments.get(2))?;
 
             let result = self(arg_0, arg_1, arg_2);
 
-            wrap_in_language_error(result.map(|v| v.into_value_with_environment(env).to_raw(gc)))
+            wrap_in_language_error(result.map(|v| v.into_value_with_library(library).to_raw(gc)))
         })
     }
 }
@@ -660,8 +660,8 @@ where
     const PARAMETER_COUNT: Self::ParameterCount = Self::ParameterCount::from_count_with_self(4);
 
     fn into_raw_foreign_function(self) -> RawForeignFunction {
-        Box::new(move |env, gc, args| {
-            let arguments = Arguments::new(args, env);
+        Box::new(move |library, gc, args| {
+            let arguments = Arguments::new(args, library);
             let arg_self = RawSelf(arguments.raw_self());
             let arg_0 = wrap_in_language_error(arguments.get(0))?;
             let arg_1 = wrap_in_language_error(arguments.get(1))?;
@@ -669,7 +669,7 @@ where
 
             let result = self(arg_self, arg_0, arg_1, arg_2);
 
-            Ok(result.into_value_with_environment(env).to_raw(gc))
+            Ok(result.into_value_with_library(library).to_raw(gc))
         })
     }
 }
@@ -688,8 +688,8 @@ where
     const PARAMETER_COUNT: Self::ParameterCount = Self::ParameterCount::from_count_with_self(4);
 
     fn into_raw_foreign_function(self) -> RawForeignFunction {
-        Box::new(move |env, gc, args| {
-            let arguments = Arguments::new(args, env);
+        Box::new(move |library, gc, args| {
+            let arguments = Arguments::new(args, library);
             let arg_self = RawSelf(arguments.raw_self());
             let arg_0 = wrap_in_language_error(arguments.get(0))?;
             let arg_1 = wrap_in_language_error(arguments.get(1))?;
@@ -697,7 +697,7 @@ where
 
             let result = self(arg_self, arg_0, arg_1, arg_2);
 
-            wrap_in_language_error(result.map(|v| v.into_value_with_environment(env).to_raw(gc)))
+            wrap_in_language_error(result.map(|v| v.into_value_with_library(library).to_raw(gc)))
         })
     }
 }
@@ -717,8 +717,8 @@ where
     const PARAMETER_COUNT: Self::ParameterCount = Self::ParameterCount::from_count_with_self(4);
 
     fn into_raw_foreign_function(self) -> RawForeignFunction {
-        Box::new(move |env, gc, args| {
-            let arguments = Arguments::new(args, env);
+        Box::new(move |library, gc, args| {
+            let arguments = Arguments::new(args, library);
             let (arg_self, _guard) = wrap_in_language_error(unsafe {
                 <Recv as SelfFromRawValue>::self_from_raw_value(arguments.raw_self())
             })?;
@@ -728,7 +728,7 @@ where
 
             let result = self(arg_self, arg_0, arg_1, arg_2);
 
-            Ok(result.into_value_with_environment(env).to_raw(gc))
+            Ok(result.into_value_with_library(library).to_raw(gc))
         })
     }
 }
@@ -748,8 +748,8 @@ where
     const PARAMETER_COUNT: Self::ParameterCount = Self::ParameterCount::from_count_with_self(4);
 
     fn into_raw_foreign_function(self) -> RawForeignFunction {
-        Box::new(move |env, gc, args| {
-            let arguments = Arguments::new(args, env);
+        Box::new(move |library, gc, args| {
+            let arguments = Arguments::new(args, library);
             let (arg_self, _guard) = wrap_in_language_error(unsafe {
                 <Recv as MutSelfFromRawValue>::mut_self_from_raw_value(arguments.raw_self())
             })?;
@@ -759,7 +759,7 @@ where
 
             let result = self(arg_self, arg_0, arg_1, arg_2);
 
-            Ok(result.into_value_with_environment(env).to_raw(gc))
+            Ok(result.into_value_with_library(library).to_raw(gc))
         })
     }
 }
@@ -780,8 +780,8 @@ where
     const PARAMETER_COUNT: Self::ParameterCount = Self::ParameterCount::from_count_with_self(4);
 
     fn into_raw_foreign_function(self) -> RawForeignFunction {
-        Box::new(move |env, gc, args| {
-            let arguments = Arguments::new(args, env);
+        Box::new(move |library, gc, args| {
+            let arguments = Arguments::new(args, library);
             let (arg_self, _guard) = wrap_in_language_error(unsafe {
                 <Recv as SelfFromRawValue>::self_from_raw_value(arguments.raw_self())
             })?;
@@ -791,7 +791,7 @@ where
 
             let result = self(arg_self, arg_0, arg_1, arg_2);
 
-            wrap_in_language_error(result.map(|v| v.into_value_with_environment(env).to_raw(gc)))
+            wrap_in_language_error(result.map(|v| v.into_value_with_library(library).to_raw(gc)))
         })
     }
 }
@@ -812,8 +812,8 @@ where
     const PARAMETER_COUNT: Self::ParameterCount = Self::ParameterCount::from_count_with_self(4);
 
     fn into_raw_foreign_function(self) -> RawForeignFunction {
-        Box::new(move |env, gc, args| {
-            let arguments = Arguments::new(args, env);
+        Box::new(move |library, gc, args| {
+            let arguments = Arguments::new(args, library);
             let (arg_self, _guard) = wrap_in_language_error(unsafe {
                 <Recv as MutSelfFromRawValue>::mut_self_from_raw_value(arguments.raw_self())
             })?;
@@ -823,7 +823,7 @@ where
 
             let result = self(arg_self, arg_0, arg_1, arg_2);
 
-            wrap_in_language_error(result.map(|v| v.into_value_with_environment(env).to_raw(gc)))
+            wrap_in_language_error(result.map(|v| v.into_value_with_library(library).to_raw(gc)))
         })
     }
 }
@@ -841,8 +841,8 @@ where
     const PARAMETER_COUNT: Self::ParameterCount = Self::ParameterCount::Fixed(4);
 
     fn into_raw_foreign_function(self) -> RawForeignFunction {
-        Box::new(move |env, gc, args| {
-            let arguments = Arguments::new(args, env);
+        Box::new(move |library, gc, args| {
+            let arguments = Arguments::new(args, library);
             let arg_0 = wrap_in_language_error(arguments.get(0))?;
             let arg_1 = wrap_in_language_error(arguments.get(1))?;
             let arg_2 = wrap_in_language_error(arguments.get(2))?;
@@ -850,7 +850,7 @@ where
 
             let result = self(arg_0, arg_1, arg_2, arg_3);
 
-            Ok(result.into_value_with_environment(env).to_raw(gc))
+            Ok(result.into_value_with_library(library).to_raw(gc))
         })
     }
 }
@@ -869,8 +869,8 @@ where
     const PARAMETER_COUNT: Self::ParameterCount = Self::ParameterCount::Fixed(4);
 
     fn into_raw_foreign_function(self) -> RawForeignFunction {
-        Box::new(move |env, gc, args| {
-            let arguments = Arguments::new(args, env);
+        Box::new(move |library, gc, args| {
+            let arguments = Arguments::new(args, library);
             let arg_0 = wrap_in_language_error(arguments.get(0))?;
             let arg_1 = wrap_in_language_error(arguments.get(1))?;
             let arg_2 = wrap_in_language_error(arguments.get(2))?;
@@ -878,7 +878,7 @@ where
 
             let result = self(arg_0, arg_1, arg_2, arg_3);
 
-            wrap_in_language_error(result.map(|v| v.into_value_with_environment(env).to_raw(gc)))
+            wrap_in_language_error(result.map(|v| v.into_value_with_library(library).to_raw(gc)))
         })
     }
 }
@@ -897,8 +897,8 @@ where
     const PARAMETER_COUNT: Self::ParameterCount = Self::ParameterCount::from_count_with_self(5);
 
     fn into_raw_foreign_function(self) -> RawForeignFunction {
-        Box::new(move |env, gc, args| {
-            let arguments = Arguments::new(args, env);
+        Box::new(move |library, gc, args| {
+            let arguments = Arguments::new(args, library);
             let arg_self = RawSelf(arguments.raw_self());
             let arg_0 = wrap_in_language_error(arguments.get(0))?;
             let arg_1 = wrap_in_language_error(arguments.get(1))?;
@@ -907,7 +907,7 @@ where
 
             let result = self(arg_self, arg_0, arg_1, arg_2, arg_3);
 
-            Ok(result.into_value_with_environment(env).to_raw(gc))
+            Ok(result.into_value_with_library(library).to_raw(gc))
         })
     }
 }
@@ -927,8 +927,8 @@ where
     const PARAMETER_COUNT: Self::ParameterCount = Self::ParameterCount::from_count_with_self(5);
 
     fn into_raw_foreign_function(self) -> RawForeignFunction {
-        Box::new(move |env, gc, args| {
-            let arguments = Arguments::new(args, env);
+        Box::new(move |library, gc, args| {
+            let arguments = Arguments::new(args, library);
             let arg_self = RawSelf(arguments.raw_self());
             let arg_0 = wrap_in_language_error(arguments.get(0))?;
             let arg_1 = wrap_in_language_error(arguments.get(1))?;
@@ -937,7 +937,7 @@ where
 
             let result = self(arg_self, arg_0, arg_1, arg_2, arg_3);
 
-            wrap_in_language_error(result.map(|v| v.into_value_with_environment(env).to_raw(gc)))
+            wrap_in_language_error(result.map(|v| v.into_value_with_library(library).to_raw(gc)))
         })
     }
 }
@@ -959,8 +959,8 @@ where
     const PARAMETER_COUNT: Self::ParameterCount = Self::ParameterCount::from_count_with_self(5);
 
     fn into_raw_foreign_function(self) -> RawForeignFunction {
-        Box::new(move |env, gc, args| {
-            let arguments = Arguments::new(args, env);
+        Box::new(move |library, gc, args| {
+            let arguments = Arguments::new(args, library);
             let (arg_self, _guard) = wrap_in_language_error(unsafe {
                 <Recv as SelfFromRawValue>::self_from_raw_value(arguments.raw_self())
             })?;
@@ -971,7 +971,7 @@ where
 
             let result = self(arg_self, arg_0, arg_1, arg_2, arg_3);
 
-            Ok(result.into_value_with_environment(env).to_raw(gc))
+            Ok(result.into_value_with_library(library).to_raw(gc))
         })
     }
 }
@@ -993,8 +993,8 @@ where
     const PARAMETER_COUNT: Self::ParameterCount = Self::ParameterCount::from_count_with_self(5);
 
     fn into_raw_foreign_function(self) -> RawForeignFunction {
-        Box::new(move |env, gc, args| {
-            let arguments = Arguments::new(args, env);
+        Box::new(move |library, gc, args| {
+            let arguments = Arguments::new(args, library);
             let (arg_self, _guard) = wrap_in_language_error(unsafe {
                 <Recv as MutSelfFromRawValue>::mut_self_from_raw_value(arguments.raw_self())
             })?;
@@ -1005,7 +1005,7 @@ where
 
             let result = self(arg_self, arg_0, arg_1, arg_2, arg_3);
 
-            Ok(result.into_value_with_environment(env).to_raw(gc))
+            Ok(result.into_value_with_library(library).to_raw(gc))
         })
     }
 }
@@ -1027,8 +1027,8 @@ where
     const PARAMETER_COUNT: Self::ParameterCount = Self::ParameterCount::from_count_with_self(5);
 
     fn into_raw_foreign_function(self) -> RawForeignFunction {
-        Box::new(move |env, gc, args| {
-            let arguments = Arguments::new(args, env);
+        Box::new(move |library, gc, args| {
+            let arguments = Arguments::new(args, library);
             let (arg_self, _guard) = wrap_in_language_error(unsafe {
                 <Recv as SelfFromRawValue>::self_from_raw_value(arguments.raw_self())
             })?;
@@ -1039,7 +1039,7 @@ where
 
             let result = self(arg_self, arg_0, arg_1, arg_2, arg_3);
 
-            wrap_in_language_error(result.map(|v| v.into_value_with_environment(env).to_raw(gc)))
+            wrap_in_language_error(result.map(|v| v.into_value_with_library(library).to_raw(gc)))
         })
     }
 }
@@ -1062,8 +1062,8 @@ where
     const PARAMETER_COUNT: Self::ParameterCount = Self::ParameterCount::from_count_with_self(5);
 
     fn into_raw_foreign_function(self) -> RawForeignFunction {
-        Box::new(move |env, gc, args| {
-            let arguments = Arguments::new(args, env);
+        Box::new(move |library, gc, args| {
+            let arguments = Arguments::new(args, library);
             let (arg_self, _guard) = wrap_in_language_error(unsafe {
                 <Recv as MutSelfFromRawValue>::mut_self_from_raw_value(arguments.raw_self())
             })?;
@@ -1074,7 +1074,7 @@ where
 
             let result = self(arg_self, arg_0, arg_1, arg_2, arg_3);
 
-            wrap_in_language_error(result.map(|v| v.into_value_with_environment(env).to_raw(gc)))
+            wrap_in_language_error(result.map(|v| v.into_value_with_library(library).to_raw(gc)))
         })
     }
 }
@@ -1093,8 +1093,8 @@ where
     const PARAMETER_COUNT: Self::ParameterCount = Self::ParameterCount::Fixed(5);
 
     fn into_raw_foreign_function(self) -> RawForeignFunction {
-        Box::new(move |env, gc, args| {
-            let arguments = Arguments::new(args, env);
+        Box::new(move |library, gc, args| {
+            let arguments = Arguments::new(args, library);
             let arg_0 = wrap_in_language_error(arguments.get(0))?;
             let arg_1 = wrap_in_language_error(arguments.get(1))?;
             let arg_2 = wrap_in_language_error(arguments.get(2))?;
@@ -1103,7 +1103,7 @@ where
 
             let result = self(arg_0, arg_1, arg_2, arg_3, arg_4);
 
-            Ok(result.into_value_with_environment(env).to_raw(gc))
+            Ok(result.into_value_with_library(library).to_raw(gc))
         })
     }
 }
@@ -1123,8 +1123,8 @@ where
     const PARAMETER_COUNT: Self::ParameterCount = Self::ParameterCount::Fixed(5);
 
     fn into_raw_foreign_function(self) -> RawForeignFunction {
-        Box::new(move |env, gc, args| {
-            let arguments = Arguments::new(args, env);
+        Box::new(move |library, gc, args| {
+            let arguments = Arguments::new(args, library);
             let arg_0 = wrap_in_language_error(arguments.get(0))?;
             let arg_1 = wrap_in_language_error(arguments.get(1))?;
             let arg_2 = wrap_in_language_error(arguments.get(2))?;
@@ -1133,7 +1133,7 @@ where
 
             let result = self(arg_0, arg_1, arg_2, arg_3, arg_4);
 
-            wrap_in_language_error(result.map(|v| v.into_value_with_environment(env).to_raw(gc)))
+            wrap_in_language_error(result.map(|v| v.into_value_with_library(library).to_raw(gc)))
         })
     }
 }
@@ -1153,8 +1153,8 @@ where
     const PARAMETER_COUNT: Self::ParameterCount = Self::ParameterCount::from_count_with_self(6);
 
     fn into_raw_foreign_function(self) -> RawForeignFunction {
-        Box::new(move |env, gc, args| {
-            let arguments = Arguments::new(args, env);
+        Box::new(move |library, gc, args| {
+            let arguments = Arguments::new(args, library);
             let arg_self = RawSelf(arguments.raw_self());
             let arg_0 = wrap_in_language_error(arguments.get(0))?;
             let arg_1 = wrap_in_language_error(arguments.get(1))?;
@@ -1164,7 +1164,7 @@ where
 
             let result = self(arg_self, arg_0, arg_1, arg_2, arg_3, arg_4);
 
-            Ok(result.into_value_with_environment(env).to_raw(gc))
+            Ok(result.into_value_with_library(library).to_raw(gc))
         })
     }
 }
@@ -1185,8 +1185,8 @@ where
     const PARAMETER_COUNT: Self::ParameterCount = Self::ParameterCount::from_count_with_self(6);
 
     fn into_raw_foreign_function(self) -> RawForeignFunction {
-        Box::new(move |env, gc, args| {
-            let arguments = Arguments::new(args, env);
+        Box::new(move |library, gc, args| {
+            let arguments = Arguments::new(args, library);
             let arg_self = RawSelf(arguments.raw_self());
             let arg_0 = wrap_in_language_error(arguments.get(0))?;
             let arg_1 = wrap_in_language_error(arguments.get(1))?;
@@ -1196,7 +1196,7 @@ where
 
             let result = self(arg_self, arg_0, arg_1, arg_2, arg_3, arg_4);
 
-            wrap_in_language_error(result.map(|v| v.into_value_with_environment(env).to_raw(gc)))
+            wrap_in_language_error(result.map(|v| v.into_value_with_library(library).to_raw(gc)))
         })
     }
 }
@@ -1219,8 +1219,8 @@ where
     const PARAMETER_COUNT: Self::ParameterCount = Self::ParameterCount::from_count_with_self(6);
 
     fn into_raw_foreign_function(self) -> RawForeignFunction {
-        Box::new(move |env, gc, args| {
-            let arguments = Arguments::new(args, env);
+        Box::new(move |library, gc, args| {
+            let arguments = Arguments::new(args, library);
             let (arg_self, _guard) = wrap_in_language_error(unsafe {
                 <Recv as SelfFromRawValue>::self_from_raw_value(arguments.raw_self())
             })?;
@@ -1232,7 +1232,7 @@ where
 
             let result = self(arg_self, arg_0, arg_1, arg_2, arg_3, arg_4);
 
-            Ok(result.into_value_with_environment(env).to_raw(gc))
+            Ok(result.into_value_with_library(library).to_raw(gc))
         })
     }
 }
@@ -1255,8 +1255,8 @@ where
     const PARAMETER_COUNT: Self::ParameterCount = Self::ParameterCount::from_count_with_self(6);
 
     fn into_raw_foreign_function(self) -> RawForeignFunction {
-        Box::new(move |env, gc, args| {
-            let arguments = Arguments::new(args, env);
+        Box::new(move |library, gc, args| {
+            let arguments = Arguments::new(args, library);
             let (arg_self, _guard) = wrap_in_language_error(unsafe {
                 <Recv as MutSelfFromRawValue>::mut_self_from_raw_value(arguments.raw_self())
             })?;
@@ -1268,7 +1268,7 @@ where
 
             let result = self(arg_self, arg_0, arg_1, arg_2, arg_3, arg_4);
 
-            Ok(result.into_value_with_environment(env).to_raw(gc))
+            Ok(result.into_value_with_library(library).to_raw(gc))
         })
     }
 }
@@ -1292,8 +1292,8 @@ where
     const PARAMETER_COUNT: Self::ParameterCount = Self::ParameterCount::from_count_with_self(6);
 
     fn into_raw_foreign_function(self) -> RawForeignFunction {
-        Box::new(move |env, gc, args| {
-            let arguments = Arguments::new(args, env);
+        Box::new(move |library, gc, args| {
+            let arguments = Arguments::new(args, library);
             let (arg_self, _guard) = wrap_in_language_error(unsafe {
                 <Recv as SelfFromRawValue>::self_from_raw_value(arguments.raw_self())
             })?;
@@ -1305,7 +1305,7 @@ where
 
             let result = self(arg_self, arg_0, arg_1, arg_2, arg_3, arg_4);
 
-            wrap_in_language_error(result.map(|v| v.into_value_with_environment(env).to_raw(gc)))
+            wrap_in_language_error(result.map(|v| v.into_value_with_library(library).to_raw(gc)))
         })
     }
 }
@@ -1329,8 +1329,8 @@ where
     const PARAMETER_COUNT: Self::ParameterCount = Self::ParameterCount::from_count_with_self(6);
 
     fn into_raw_foreign_function(self) -> RawForeignFunction {
-        Box::new(move |env, gc, args| {
-            let arguments = Arguments::new(args, env);
+        Box::new(move |library, gc, args| {
+            let arguments = Arguments::new(args, library);
             let (arg_self, _guard) = wrap_in_language_error(unsafe {
                 <Recv as MutSelfFromRawValue>::mut_self_from_raw_value(arguments.raw_self())
             })?;
@@ -1342,7 +1342,7 @@ where
 
             let result = self(arg_self, arg_0, arg_1, arg_2, arg_3, arg_4);
 
-            wrap_in_language_error(result.map(|v| v.into_value_with_environment(env).to_raw(gc)))
+            wrap_in_language_error(result.map(|v| v.into_value_with_library(library).to_raw(gc)))
         })
     }
 }
@@ -1362,8 +1362,8 @@ where
     const PARAMETER_COUNT: Self::ParameterCount = Self::ParameterCount::Fixed(6);
 
     fn into_raw_foreign_function(self) -> RawForeignFunction {
-        Box::new(move |env, gc, args| {
-            let arguments = Arguments::new(args, env);
+        Box::new(move |library, gc, args| {
+            let arguments = Arguments::new(args, library);
             let arg_0 = wrap_in_language_error(arguments.get(0))?;
             let arg_1 = wrap_in_language_error(arguments.get(1))?;
             let arg_2 = wrap_in_language_error(arguments.get(2))?;
@@ -1373,7 +1373,7 @@ where
 
             let result = self(arg_0, arg_1, arg_2, arg_3, arg_4, arg_5);
 
-            Ok(result.into_value_with_environment(env).to_raw(gc))
+            Ok(result.into_value_with_library(library).to_raw(gc))
         })
     }
 }
@@ -1395,8 +1395,8 @@ where
     const PARAMETER_COUNT: Self::ParameterCount = Self::ParameterCount::Fixed(6);
 
     fn into_raw_foreign_function(self) -> RawForeignFunction {
-        Box::new(move |env, gc, args| {
-            let arguments = Arguments::new(args, env);
+        Box::new(move |library, gc, args| {
+            let arguments = Arguments::new(args, library);
             let arg_0 = wrap_in_language_error(arguments.get(0))?;
             let arg_1 = wrap_in_language_error(arguments.get(1))?;
             let arg_2 = wrap_in_language_error(arguments.get(2))?;
@@ -1406,7 +1406,7 @@ where
 
             let result = self(arg_0, arg_1, arg_2, arg_3, arg_4, arg_5);
 
-            wrap_in_language_error(result.map(|v| v.into_value_with_environment(env).to_raw(gc)))
+            wrap_in_language_error(result.map(|v| v.into_value_with_library(library).to_raw(gc)))
         })
     }
 }
@@ -1427,8 +1427,8 @@ where
     const PARAMETER_COUNT: Self::ParameterCount = Self::ParameterCount::from_count_with_self(7);
 
     fn into_raw_foreign_function(self) -> RawForeignFunction {
-        Box::new(move |env, gc, args| {
-            let arguments = Arguments::new(args, env);
+        Box::new(move |library, gc, args| {
+            let arguments = Arguments::new(args, library);
             let arg_self = RawSelf(arguments.raw_self());
             let arg_0 = wrap_in_language_error(arguments.get(0))?;
             let arg_1 = wrap_in_language_error(arguments.get(1))?;
@@ -1439,7 +1439,7 @@ where
 
             let result = self(arg_self, arg_0, arg_1, arg_2, arg_3, arg_4, arg_5);
 
-            Ok(result.into_value_with_environment(env).to_raw(gc))
+            Ok(result.into_value_with_library(library).to_raw(gc))
         })
     }
 }
@@ -1461,8 +1461,8 @@ where
     const PARAMETER_COUNT: Self::ParameterCount = Self::ParameterCount::from_count_with_self(7);
 
     fn into_raw_foreign_function(self) -> RawForeignFunction {
-        Box::new(move |env, gc, args| {
-            let arguments = Arguments::new(args, env);
+        Box::new(move |library, gc, args| {
+            let arguments = Arguments::new(args, library);
             let arg_self = RawSelf(arguments.raw_self());
             let arg_0 = wrap_in_language_error(arguments.get(0))?;
             let arg_1 = wrap_in_language_error(arguments.get(1))?;
@@ -1473,7 +1473,7 @@ where
 
             let result = self(arg_self, arg_0, arg_1, arg_2, arg_3, arg_4, arg_5);
 
-            wrap_in_language_error(result.map(|v| v.into_value_with_environment(env).to_raw(gc)))
+            wrap_in_language_error(result.map(|v| v.into_value_with_library(library).to_raw(gc)))
         })
     }
 }
@@ -1497,8 +1497,8 @@ where
     const PARAMETER_COUNT: Self::ParameterCount = Self::ParameterCount::from_count_with_self(7);
 
     fn into_raw_foreign_function(self) -> RawForeignFunction {
-        Box::new(move |env, gc, args| {
-            let arguments = Arguments::new(args, env);
+        Box::new(move |library, gc, args| {
+            let arguments = Arguments::new(args, library);
             let (arg_self, _guard) = wrap_in_language_error(unsafe {
                 <Recv as SelfFromRawValue>::self_from_raw_value(arguments.raw_self())
             })?;
@@ -1511,7 +1511,7 @@ where
 
             let result = self(arg_self, arg_0, arg_1, arg_2, arg_3, arg_4, arg_5);
 
-            Ok(result.into_value_with_environment(env).to_raw(gc))
+            Ok(result.into_value_with_library(library).to_raw(gc))
         })
     }
 }
@@ -1535,8 +1535,8 @@ where
     const PARAMETER_COUNT: Self::ParameterCount = Self::ParameterCount::from_count_with_self(7);
 
     fn into_raw_foreign_function(self) -> RawForeignFunction {
-        Box::new(move |env, gc, args| {
-            let arguments = Arguments::new(args, env);
+        Box::new(move |library, gc, args| {
+            let arguments = Arguments::new(args, library);
             let (arg_self, _guard) = wrap_in_language_error(unsafe {
                 <Recv as MutSelfFromRawValue>::mut_self_from_raw_value(arguments.raw_self())
             })?;
@@ -1549,7 +1549,7 @@ where
 
             let result = self(arg_self, arg_0, arg_1, arg_2, arg_3, arg_4, arg_5);
 
-            Ok(result.into_value_with_environment(env).to_raw(gc))
+            Ok(result.into_value_with_library(library).to_raw(gc))
         })
     }
 }
@@ -1574,8 +1574,8 @@ where
     const PARAMETER_COUNT: Self::ParameterCount = Self::ParameterCount::from_count_with_self(7);
 
     fn into_raw_foreign_function(self) -> RawForeignFunction {
-        Box::new(move |env, gc, args| {
-            let arguments = Arguments::new(args, env);
+        Box::new(move |library, gc, args| {
+            let arguments = Arguments::new(args, library);
             let (arg_self, _guard) = wrap_in_language_error(unsafe {
                 <Recv as SelfFromRawValue>::self_from_raw_value(arguments.raw_self())
             })?;
@@ -1588,7 +1588,7 @@ where
 
             let result = self(arg_self, arg_0, arg_1, arg_2, arg_3, arg_4, arg_5);
 
-            wrap_in_language_error(result.map(|v| v.into_value_with_environment(env).to_raw(gc)))
+            wrap_in_language_error(result.map(|v| v.into_value_with_library(library).to_raw(gc)))
         })
     }
 }
@@ -1613,8 +1613,8 @@ where
     const PARAMETER_COUNT: Self::ParameterCount = Self::ParameterCount::from_count_with_self(7);
 
     fn into_raw_foreign_function(self) -> RawForeignFunction {
-        Box::new(move |env, gc, args| {
-            let arguments = Arguments::new(args, env);
+        Box::new(move |library, gc, args| {
+            let arguments = Arguments::new(args, library);
             let (arg_self, _guard) = wrap_in_language_error(unsafe {
                 <Recv as MutSelfFromRawValue>::mut_self_from_raw_value(arguments.raw_self())
             })?;
@@ -1627,7 +1627,7 @@ where
 
             let result = self(arg_self, arg_0, arg_1, arg_2, arg_3, arg_4, arg_5);
 
-            wrap_in_language_error(result.map(|v| v.into_value_with_environment(env).to_raw(gc)))
+            wrap_in_language_error(result.map(|v| v.into_value_with_library(library).to_raw(gc)))
         })
     }
 }
@@ -1649,8 +1649,8 @@ where
     const PARAMETER_COUNT: Self::ParameterCount = Self::ParameterCount::Fixed(7);
 
     fn into_raw_foreign_function(self) -> RawForeignFunction {
-        Box::new(move |env, gc, args| {
-            let arguments = Arguments::new(args, env);
+        Box::new(move |library, gc, args| {
+            let arguments = Arguments::new(args, library);
             let arg_0 = wrap_in_language_error(arguments.get(0))?;
             let arg_1 = wrap_in_language_error(arguments.get(1))?;
             let arg_2 = wrap_in_language_error(arguments.get(2))?;
@@ -1661,7 +1661,7 @@ where
 
             let result = self(arg_0, arg_1, arg_2, arg_3, arg_4, arg_5, arg_6);
 
-            Ok(result.into_value_with_environment(env).to_raw(gc))
+            Ok(result.into_value_with_library(library).to_raw(gc))
         })
     }
 }
@@ -1684,8 +1684,8 @@ where
     const PARAMETER_COUNT: Self::ParameterCount = Self::ParameterCount::Fixed(7);
 
     fn into_raw_foreign_function(self) -> RawForeignFunction {
-        Box::new(move |env, gc, args| {
-            let arguments = Arguments::new(args, env);
+        Box::new(move |library, gc, args| {
+            let arguments = Arguments::new(args, library);
             let arg_0 = wrap_in_language_error(arguments.get(0))?;
             let arg_1 = wrap_in_language_error(arguments.get(1))?;
             let arg_2 = wrap_in_language_error(arguments.get(2))?;
@@ -1696,7 +1696,7 @@ where
 
             let result = self(arg_0, arg_1, arg_2, arg_3, arg_4, arg_5, arg_6);
 
-            wrap_in_language_error(result.map(|v| v.into_value_with_environment(env).to_raw(gc)))
+            wrap_in_language_error(result.map(|v| v.into_value_with_library(library).to_raw(gc)))
         })
     }
 }
@@ -1718,8 +1718,8 @@ where
     const PARAMETER_COUNT: Self::ParameterCount = Self::ParameterCount::from_count_with_self(8);
 
     fn into_raw_foreign_function(self) -> RawForeignFunction {
-        Box::new(move |env, gc, args| {
-            let arguments = Arguments::new(args, env);
+        Box::new(move |library, gc, args| {
+            let arguments = Arguments::new(args, library);
             let arg_self = RawSelf(arguments.raw_self());
             let arg_0 = wrap_in_language_error(arguments.get(0))?;
             let arg_1 = wrap_in_language_error(arguments.get(1))?;
@@ -1731,7 +1731,7 @@ where
 
             let result = self(arg_self, arg_0, arg_1, arg_2, arg_3, arg_4, arg_5, arg_6);
 
-            Ok(result.into_value_with_environment(env).to_raw(gc))
+            Ok(result.into_value_with_library(library).to_raw(gc))
         })
     }
 }
@@ -1754,8 +1754,8 @@ where
     const PARAMETER_COUNT: Self::ParameterCount = Self::ParameterCount::from_count_with_self(8);
 
     fn into_raw_foreign_function(self) -> RawForeignFunction {
-        Box::new(move |env, gc, args| {
-            let arguments = Arguments::new(args, env);
+        Box::new(move |library, gc, args| {
+            let arguments = Arguments::new(args, library);
             let arg_self = RawSelf(arguments.raw_self());
             let arg_0 = wrap_in_language_error(arguments.get(0))?;
             let arg_1 = wrap_in_language_error(arguments.get(1))?;
@@ -1767,7 +1767,7 @@ where
 
             let result = self(arg_self, arg_0, arg_1, arg_2, arg_3, arg_4, arg_5, arg_6);
 
-            wrap_in_language_error(result.map(|v| v.into_value_with_environment(env).to_raw(gc)))
+            wrap_in_language_error(result.map(|v| v.into_value_with_library(library).to_raw(gc)))
         })
     }
 }
@@ -1792,8 +1792,8 @@ where
     const PARAMETER_COUNT: Self::ParameterCount = Self::ParameterCount::from_count_with_self(8);
 
     fn into_raw_foreign_function(self) -> RawForeignFunction {
-        Box::new(move |env, gc, args| {
-            let arguments = Arguments::new(args, env);
+        Box::new(move |library, gc, args| {
+            let arguments = Arguments::new(args, library);
             let (arg_self, _guard) = wrap_in_language_error(unsafe {
                 <Recv as SelfFromRawValue>::self_from_raw_value(arguments.raw_self())
             })?;
@@ -1807,7 +1807,7 @@ where
 
             let result = self(arg_self, arg_0, arg_1, arg_2, arg_3, arg_4, arg_5, arg_6);
 
-            Ok(result.into_value_with_environment(env).to_raw(gc))
+            Ok(result.into_value_with_library(library).to_raw(gc))
         })
     }
 }
@@ -1832,8 +1832,8 @@ where
     const PARAMETER_COUNT: Self::ParameterCount = Self::ParameterCount::from_count_with_self(8);
 
     fn into_raw_foreign_function(self) -> RawForeignFunction {
-        Box::new(move |env, gc, args| {
-            let arguments = Arguments::new(args, env);
+        Box::new(move |library, gc, args| {
+            let arguments = Arguments::new(args, library);
             let (arg_self, _guard) = wrap_in_language_error(unsafe {
                 <Recv as MutSelfFromRawValue>::mut_self_from_raw_value(arguments.raw_self())
             })?;
@@ -1847,7 +1847,7 @@ where
 
             let result = self(arg_self, arg_0, arg_1, arg_2, arg_3, arg_4, arg_5, arg_6);
 
-            Ok(result.into_value_with_environment(env).to_raw(gc))
+            Ok(result.into_value_with_library(library).to_raw(gc))
         })
     }
 }
@@ -1873,8 +1873,8 @@ where
     const PARAMETER_COUNT: Self::ParameterCount = Self::ParameterCount::from_count_with_self(8);
 
     fn into_raw_foreign_function(self) -> RawForeignFunction {
-        Box::new(move |env, gc, args| {
-            let arguments = Arguments::new(args, env);
+        Box::new(move |library, gc, args| {
+            let arguments = Arguments::new(args, library);
             let (arg_self, _guard) = wrap_in_language_error(unsafe {
                 <Recv as SelfFromRawValue>::self_from_raw_value(arguments.raw_self())
             })?;
@@ -1888,7 +1888,7 @@ where
 
             let result = self(arg_self, arg_0, arg_1, arg_2, arg_3, arg_4, arg_5, arg_6);
 
-            wrap_in_language_error(result.map(|v| v.into_value_with_environment(env).to_raw(gc)))
+            wrap_in_language_error(result.map(|v| v.into_value_with_library(library).to_raw(gc)))
         })
     }
 }
@@ -1914,8 +1914,8 @@ where
     const PARAMETER_COUNT: Self::ParameterCount = Self::ParameterCount::from_count_with_self(8);
 
     fn into_raw_foreign_function(self) -> RawForeignFunction {
-        Box::new(move |env, gc, args| {
-            let arguments = Arguments::new(args, env);
+        Box::new(move |library, gc, args| {
+            let arguments = Arguments::new(args, library);
             let (arg_self, _guard) = wrap_in_language_error(unsafe {
                 <Recv as MutSelfFromRawValue>::mut_self_from_raw_value(arguments.raw_self())
             })?;
@@ -1929,7 +1929,7 @@ where
 
             let result = self(arg_self, arg_0, arg_1, arg_2, arg_3, arg_4, arg_5, arg_6);
 
-            wrap_in_language_error(result.map(|v| v.into_value_with_environment(env).to_raw(gc)))
+            wrap_in_language_error(result.map(|v| v.into_value_with_library(library).to_raw(gc)))
         })
     }
 }
@@ -1952,8 +1952,8 @@ where
     const PARAMETER_COUNT: Self::ParameterCount = Self::ParameterCount::Fixed(8);
 
     fn into_raw_foreign_function(self) -> RawForeignFunction {
-        Box::new(move |env, gc, args| {
-            let arguments = Arguments::new(args, env);
+        Box::new(move |library, gc, args| {
+            let arguments = Arguments::new(args, library);
             let arg_0 = wrap_in_language_error(arguments.get(0))?;
             let arg_1 = wrap_in_language_error(arguments.get(1))?;
             let arg_2 = wrap_in_language_error(arguments.get(2))?;
@@ -1965,7 +1965,7 @@ where
 
             let result = self(arg_0, arg_1, arg_2, arg_3, arg_4, arg_5, arg_6, arg_7);
 
-            Ok(result.into_value_with_environment(env).to_raw(gc))
+            Ok(result.into_value_with_library(library).to_raw(gc))
         })
     }
 }
@@ -1989,8 +1989,8 @@ where
     const PARAMETER_COUNT: Self::ParameterCount = Self::ParameterCount::Fixed(8);
 
     fn into_raw_foreign_function(self) -> RawForeignFunction {
-        Box::new(move |env, gc, args| {
-            let arguments = Arguments::new(args, env);
+        Box::new(move |library, gc, args| {
+            let arguments = Arguments::new(args, library);
             let arg_0 = wrap_in_language_error(arguments.get(0))?;
             let arg_1 = wrap_in_language_error(arguments.get(1))?;
             let arg_2 = wrap_in_language_error(arguments.get(2))?;
@@ -2002,7 +2002,7 @@ where
 
             let result = self(arg_0, arg_1, arg_2, arg_3, arg_4, arg_5, arg_6, arg_7);
 
-            wrap_in_language_error(result.map(|v| v.into_value_with_environment(env).to_raw(gc)))
+            wrap_in_language_error(result.map(|v| v.into_value_with_library(library).to_raw(gc)))
         })
     }
 }
@@ -2025,8 +2025,8 @@ where
     const PARAMETER_COUNT: Self::ParameterCount = Self::ParameterCount::from_count_with_self(9);
 
     fn into_raw_foreign_function(self) -> RawForeignFunction {
-        Box::new(move |env, gc, args| {
-            let arguments = Arguments::new(args, env);
+        Box::new(move |library, gc, args| {
+            let arguments = Arguments::new(args, library);
             let arg_self = RawSelf(arguments.raw_self());
             let arg_0 = wrap_in_language_error(arguments.get(0))?;
             let arg_1 = wrap_in_language_error(arguments.get(1))?;
@@ -2039,7 +2039,7 @@ where
 
             let result = self(arg_self, arg_0, arg_1, arg_2, arg_3, arg_4, arg_5, arg_6, arg_7);
 
-            Ok(result.into_value_with_environment(env).to_raw(gc))
+            Ok(result.into_value_with_library(library).to_raw(gc))
         })
     }
 }
@@ -2063,8 +2063,8 @@ where
     const PARAMETER_COUNT: Self::ParameterCount = Self::ParameterCount::from_count_with_self(9);
 
     fn into_raw_foreign_function(self) -> RawForeignFunction {
-        Box::new(move |env, gc, args| {
-            let arguments = Arguments::new(args, env);
+        Box::new(move |library, gc, args| {
+            let arguments = Arguments::new(args, library);
             let arg_self = RawSelf(arguments.raw_self());
             let arg_0 = wrap_in_language_error(arguments.get(0))?;
             let arg_1 = wrap_in_language_error(arguments.get(1))?;
@@ -2077,7 +2077,7 @@ where
 
             let result = self(arg_self, arg_0, arg_1, arg_2, arg_3, arg_4, arg_5, arg_6, arg_7);
 
-            wrap_in_language_error(result.map(|v| v.into_value_with_environment(env).to_raw(gc)))
+            wrap_in_language_error(result.map(|v| v.into_value_with_library(library).to_raw(gc)))
         })
     }
 }
@@ -2106,8 +2106,8 @@ where
     const PARAMETER_COUNT: Self::ParameterCount = Self::ParameterCount::from_count_with_self(9);
 
     fn into_raw_foreign_function(self) -> RawForeignFunction {
-        Box::new(move |env, gc, args| {
-            let arguments = Arguments::new(args, env);
+        Box::new(move |library, gc, args| {
+            let arguments = Arguments::new(args, library);
             let (arg_self, _guard) = wrap_in_language_error(unsafe {
                 <Recv as SelfFromRawValue>::self_from_raw_value(arguments.raw_self())
             })?;
@@ -2122,7 +2122,7 @@ where
 
             let result = self(arg_self, arg_0, arg_1, arg_2, arg_3, arg_4, arg_5, arg_6, arg_7);
 
-            Ok(result.into_value_with_environment(env).to_raw(gc))
+            Ok(result.into_value_with_library(library).to_raw(gc))
         })
     }
 }
@@ -2151,8 +2151,8 @@ where
     const PARAMETER_COUNT: Self::ParameterCount = Self::ParameterCount::from_count_with_self(9);
 
     fn into_raw_foreign_function(self) -> RawForeignFunction {
-        Box::new(move |env, gc, args| {
-            let arguments = Arguments::new(args, env);
+        Box::new(move |library, gc, args| {
+            let arguments = Arguments::new(args, library);
             let (arg_self, _guard) = wrap_in_language_error(unsafe {
                 <Recv as MutSelfFromRawValue>::mut_self_from_raw_value(arguments.raw_self())
             })?;
@@ -2167,7 +2167,7 @@ where
 
             let result = self(arg_self, arg_0, arg_1, arg_2, arg_3, arg_4, arg_5, arg_6, arg_7);
 
-            Ok(result.into_value_with_environment(env).to_raw(gc))
+            Ok(result.into_value_with_library(library).to_raw(gc))
         })
     }
 }
@@ -2194,8 +2194,8 @@ where
     const PARAMETER_COUNT: Self::ParameterCount = Self::ParameterCount::from_count_with_self(9);
 
     fn into_raw_foreign_function(self) -> RawForeignFunction {
-        Box::new(move |env, gc, args| {
-            let arguments = Arguments::new(args, env);
+        Box::new(move |library, gc, args| {
+            let arguments = Arguments::new(args, library);
             let (arg_self, _guard) = wrap_in_language_error(unsafe {
                 <Recv as SelfFromRawValue>::self_from_raw_value(arguments.raw_self())
             })?;
@@ -2210,7 +2210,7 @@ where
 
             let result = self(arg_self, arg_0, arg_1, arg_2, arg_3, arg_4, arg_5, arg_6, arg_7);
 
-            wrap_in_language_error(result.map(|v| v.into_value_with_environment(env).to_raw(gc)))
+            wrap_in_language_error(result.map(|v| v.into_value_with_library(library).to_raw(gc)))
         })
     }
 }
@@ -2240,8 +2240,8 @@ where
     const PARAMETER_COUNT: Self::ParameterCount = Self::ParameterCount::from_count_with_self(9);
 
     fn into_raw_foreign_function(self) -> RawForeignFunction {
-        Box::new(move |env, gc, args| {
-            let arguments = Arguments::new(args, env);
+        Box::new(move |library, gc, args| {
+            let arguments = Arguments::new(args, library);
             let (arg_self, _guard) = wrap_in_language_error(unsafe {
                 <Recv as MutSelfFromRawValue>::mut_self_from_raw_value(arguments.raw_self())
             })?;
@@ -2256,7 +2256,7 @@ where
 
             let result = self(arg_self, arg_0, arg_1, arg_2, arg_3, arg_4, arg_5, arg_6, arg_7);
 
-            wrap_in_language_error(result.map(|v| v.into_value_with_environment(env).to_raw(gc)))
+            wrap_in_language_error(result.map(|v| v.into_value_with_library(library).to_raw(gc)))
         })
     }
 }

--- a/src/hl/userdata.rs
+++ b/src/hl/userdata.rs
@@ -9,7 +9,7 @@ use std::{
 
 use crate::{
     ll::{
-        bytecode::{DispatchTable, Environment},
+        bytecode::{DispatchTable, Library},
         error::LanguageErrorKind,
         gc::{Gc, GcRaw},
         value::{self, RawValue},
@@ -76,7 +76,7 @@ impl<T> value::UserData for Type<T>
 where
     T: Any,
 {
-    fn dtable_gcraw(&self, _: Option<&Environment>) -> GcRaw<DispatchTable> {
+    fn dtable_gcraw(&self, _: Option<&Library>) -> GcRaw<DispatchTable> {
         Gc::as_raw(&self.dtable)
     }
 
@@ -172,7 +172,7 @@ impl<T> value::UserData for Object<T>
 where
     T: Any,
 {
-    fn dtable_gcraw(&self, _: Option<&Environment>) -> GcRaw<DispatchTable> {
+    fn dtable_gcraw(&self, _: Option<&Library>) -> GcRaw<DispatchTable> {
         Gc::as_raw(&self.dtable)
     }
 

--- a/src/ll/bytecode.rs
+++ b/src/ll/bytecode.rs
@@ -5,9 +5,11 @@ mod dispatch_table;
 mod environment;
 mod function;
 mod impls;
+mod library;
 mod opcode;
 mod opr24;
 
 pub use self::{
-    chunk::*, dispatch_table::*, environment::*, function::*, impls::*, opcode::*, opr24::*,
+    chunk::*, dispatch_table::*, environment::*, function::*, impls::*, library::*, opcode::*,
+    opr24::*,
 };

--- a/src/ll/bytecode/dispatch_table.rs
+++ b/src/ll/bytecode/dispatch_table.rs
@@ -1,10 +1,7 @@
 use std::rc::Rc;
 
 use super::MethodIndex;
-use crate::{
-    ll::{gc::GcRaw, value::Closure},
-    Gc,
-};
+use crate::ll::{gc::GcRaw, value::Closure};
 
 /// A dispatch table containing functions bound to an instance of a value.
 #[derive(Debug)]
@@ -58,33 +55,5 @@ impl DispatchTable {
     /// Returns an iterator over all methods in this dispatch table.
     pub(crate) fn methods(&self) -> impl Iterator<Item = GcRaw<Closure>> + '_ {
         self.methods.iter().copied().flatten()
-    }
-}
-
-/// Dispatch tables for instances of builtin types. These should be constructed by the standard
-/// library.
-#[derive(Debug)]
-pub struct BuiltinDispatchTables {
-    pub nil: Gc<DispatchTable>,
-    pub boolean: Gc<DispatchTable>,
-    pub number: Gc<DispatchTable>,
-    pub string: Gc<DispatchTable>,
-    pub function: Gc<DispatchTable>,
-    pub list: Gc<DispatchTable>,
-    pub dict: Gc<DispatchTable>,
-}
-
-/// Default dispatch tables for built-in types are empty and do not implement any methods.
-impl BuiltinDispatchTables {
-    pub fn empty() -> Self {
-        Self {
-            nil: Gc::new(DispatchTable::new("Nil", "Nil")),
-            boolean: Gc::new(DispatchTable::new("Boolean", "Boolean")),
-            number: Gc::new(DispatchTable::new("Number", "Boolean")),
-            string: Gc::new(DispatchTable::new("String", "String")),
-            function: Gc::new(DispatchTable::new("Function", "Function")),
-            list: Gc::new(DispatchTable::new("List", "List")),
-            dict: Gc::new(DispatchTable::new("Dict", "Dict")),
-        }
     }
 }

--- a/src/ll/bytecode/environment.rs
+++ b/src/ll/bytecode/environment.rs
@@ -1,16 +1,14 @@
 //! Static execution environment.
 
 use std::{
-    any::{Any, TypeId},
     collections::{HashMap, HashSet},
     rc::Rc,
 };
 
-use super::{BuiltinDispatchTables, DispatchTable, Function, Opr24, Prototype, TraitPrototype};
+use super::{Function, Opr24, Prototype, TraitPrototype};
 use crate::ll::{
     bytecode::MethodParameterCount,
     error::{LanguageErrorKind, RenderedSignature},
-    gc::Gc,
 };
 
 /// The unique index of a function.
@@ -128,7 +126,7 @@ impl TraitIndex {
 }
 
 /// An environment containing information about declared globals, functions, vtables.
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct Environment {
     /// Mapping from global names to global slots.
     globals: HashMap<String, GlobalIndex>,
@@ -141,11 +139,6 @@ pub struct Environment {
     /// Mapping from method indices to function signatures.
     method_signatures: Vec<MethodSignature>,
 
-    /// Dispatch tables for builtin types.
-    pub builtin_dtables: BuiltinDispatchTables,
-    /// Dispatch tables for user types.
-    user_dtables: HashMap<TypeId, Gc<DispatchTable>>,
-
     /// `impl` prototypes.
     prototypes: Vec<Option<Prototype>>,
     /// Trait prototypes.
@@ -154,17 +147,8 @@ pub struct Environment {
 
 impl Environment {
     /// Creates a new, empty environment.
-    pub fn new(builtin_dtables: BuiltinDispatchTables) -> Self {
-        Self {
-            globals: HashMap::new(),
-            functions: Vec::new(),
-            method_indices: HashMap::new(),
-            method_signatures: Vec::new(),
-            builtin_dtables,
-            user_dtables: HashMap::new(),
-            prototypes: Vec::new(),
-            traits: Vec::new(),
-        }
+    pub fn new() -> Self {
+        Self::default()
     }
 
     /// Tries to create a global. Returns the global slot number, or an error if there are too many
@@ -279,22 +263,5 @@ impl Environment {
     pub fn get_trait_mut(&mut self, id: TraitIndex) -> Option<&mut TraitPrototype> {
         let TraitIndex(id) = id;
         self.traits.get_mut(usize::from(id))
-    }
-
-    /// Adds a dispatch table for a user-defined type.
-    pub fn add_user_dtable<T>(&mut self, dtable: Gc<DispatchTable>)
-    where
-        T: Any,
-    {
-        let type_id = TypeId::of::<T>();
-        self.user_dtables.insert(type_id, dtable);
-    }
-
-    /// Returns the user-defined dispatch table, if available.
-    pub fn get_user_dtable<T>(&self) -> Option<&Gc<DispatchTable>>
-    where
-        T: Any,
-    {
-        self.user_dtables.get(&TypeId::of::<T>())
     }
 }

--- a/src/ll/bytecode/function.rs
+++ b/src/ll/bytecode/function.rs
@@ -2,7 +2,7 @@
 
 use std::rc::Rc;
 
-use super::{Chunk, Environment};
+use super::{Chunk, Library};
 use crate::ll::{
     codegen::variables::{LocalIndex, UpvalueIndex},
     error::LanguageErrorKind,
@@ -21,7 +21,7 @@ pub enum CaptureKind {
 
 /// The signature of a raw foreign function.
 pub type ForeignFunction =
-    Box<dyn Fn(&Environment, &mut Memory, &[RawValue]) -> Result<RawValue, LanguageErrorKind>>;
+    Box<dyn Fn(&Library, &mut Memory, &[RawValue]) -> Result<RawValue, LanguageErrorKind>>;
 
 /// The kind of a controlling function.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/src/ll/bytecode/impls.rs
+++ b/src/ll/bytecode/impls.rs
@@ -5,11 +5,8 @@ use std::{
     rc::Rc,
 };
 
-use super::{Environment, FunctionIndex, MethodIndex, TraitIndex};
-use crate::{
-    ll::{codegen::TraitBuilder, error::LanguageErrorKind},
-    MethodParameterCount,
-};
+use super::{FunctionIndex, MethodIndex};
+use crate::{ll::error::LanguageErrorKind, MethodParameterCount};
 
 /// The index of a trait in an `impl` block.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -68,35 +65,4 @@ pub struct TraitPrototype {
     pub required: HashSet<MethodIndex>,
     /// List of `(method_id, function_id)` mappings that make up the dtable of shims for the trait.
     pub shims: Vec<(MethodIndex, FunctionIndex)>,
-}
-
-/// IDs of built-in traits and their methods.
-#[derive(Debug)]
-pub struct BuiltinTraits {
-    pub iterator: TraitIndex,
-    pub iterator_has_next: MethodIndex,
-    pub iterator_next: MethodIndex,
-}
-
-impl BuiltinTraits {
-    /// Tries to register built-in traits in the given environment.
-    fn try_register_in(env: &mut Environment) -> Result<Self, LanguageErrorKind> {
-        let mut builder = TraitBuilder::new(env, None, Rc::from("Iterator"))?;
-        let iterator_has_next = builder
-            .add_method(Rc::from("has_next"), MethodParameterCount::from_count_with_self(1))?;
-        let iterator_next =
-            builder.add_method(Rc::from("next"), MethodParameterCount::from_count_with_self(1))?;
-        let (iterator, _) = builder.build();
-
-        Ok(Self { iterator, iterator_has_next, iterator_next })
-    }
-
-    /// Registers built-in traits in the given environment.
-    ///
-    /// # Panics
-    /// If there are too many traits, methods, or functions registered in the environment.
-    pub fn register_in(env: &mut Environment) -> Self {
-        Self::try_register_in(env)
-            .expect("environment should have enough space for built-in traits")
-    }
 }

--- a/src/ll/bytecode/library.rs
+++ b/src/ll/bytecode/library.rs
@@ -1,0 +1,107 @@
+use std::{
+    any::{Any, TypeId},
+    collections::HashMap,
+    rc::Rc,
+};
+
+use super::{DispatchTable, Environment, MethodIndex, TraitIndex};
+use crate::{
+    ll::{codegen::TraitBuilder, error::LanguageErrorKind},
+    Gc, MethodParameterCount,
+};
+
+/// Aggregate of all dispatch tables and traits available to a VM.
+#[derive(Debug)]
+pub struct Library {
+    /// Built-in dispatch tables. This has to be initialized with proper dtables by the core
+    /// library.
+    pub builtin_dtables: BuiltinDispatchTables,
+    /// Built-in traits. This is initialized by the compiler itself after the environment is
+    /// available.
+    pub builtin_traits: BuiltinTraits,
+
+    /// Dispatch tables for user types.
+    user_dtables: HashMap<TypeId, Gc<DispatchTable>>,
+}
+
+impl Library {
+    pub fn new(builtin_dtables: BuiltinDispatchTables, builtin_traits: BuiltinTraits) -> Self {
+        Self { builtin_dtables, builtin_traits, user_dtables: HashMap::new() }
+    }
+
+    /// Adds a dispatch table for a user-defined type.
+    pub fn add_user_dtable<T>(&mut self, dtable: Gc<DispatchTable>)
+    where
+        T: Any,
+    {
+        let type_id = TypeId::of::<T>();
+        self.user_dtables.insert(type_id, dtable);
+    }
+
+    /// Returns the user-defined dispatch table, if available.
+    pub fn get_user_dtable<T>(&self) -> Option<&Gc<DispatchTable>>
+    where
+        T: Any,
+    {
+        self.user_dtables.get(&TypeId::of::<T>())
+    }
+}
+
+/// Dispatch tables for instances of builtin types. These should be constructed by the core
+/// library.
+#[derive(Debug)]
+pub struct BuiltinDispatchTables {
+    pub nil: Gc<DispatchTable>,
+    pub boolean: Gc<DispatchTable>,
+    pub number: Gc<DispatchTable>,
+    pub string: Gc<DispatchTable>,
+    pub function: Gc<DispatchTable>,
+    pub list: Gc<DispatchTable>,
+    pub dict: Gc<DispatchTable>,
+}
+
+/// Default dispatch tables for built-in types are empty and do not implement any methods.
+impl BuiltinDispatchTables {
+    pub fn empty() -> Self {
+        Self {
+            nil: Gc::new(DispatchTable::new_for_instance("Nil")),
+            boolean: Gc::new(DispatchTable::new_for_instance("Boolean")),
+            number: Gc::new(DispatchTable::new_for_instance("Number")),
+            string: Gc::new(DispatchTable::new_for_instance("String")),
+            function: Gc::new(DispatchTable::new_for_instance("Function")),
+            list: Gc::new(DispatchTable::new_for_instance("List")),
+            dict: Gc::new(DispatchTable::new_for_instance("Dict")),
+        }
+    }
+}
+
+/// IDs of built-in traits and their methods.
+#[derive(Debug)]
+pub struct BuiltinTraits {
+    pub iterator: TraitIndex,
+    pub iterator_has_next: MethodIndex,
+    pub iterator_next: MethodIndex,
+}
+
+impl BuiltinTraits {
+    /// Tries to register built-in traits in the given environment.
+    fn try_register_in(env: &mut Environment) -> Result<Self, LanguageErrorKind> {
+        let mut builder = TraitBuilder::new(env, None, Rc::from("Iterator"))?;
+        let iterator_has_next = builder
+            .add_method(Rc::from("has_next"), MethodParameterCount::from_count_with_self(1))?;
+        let iterator_next =
+            builder.add_method(Rc::from("next"), MethodParameterCount::from_count_with_self(1))?;
+        let (iterator, _) = builder.build();
+
+        Ok(Self { iterator, iterator_has_next, iterator_next })
+    }
+
+    /// Registers built-in traits in the given environment.
+    ///
+    /// # Panics
+    /// If there are too many traits, methods, or functions registered in the environment.
+    pub fn register_in(env: &mut Environment) -> Self {
+        Self::try_register_in(env)
+            .expect("environment should have enough space for built-in traits")
+    }
+}

--- a/src/ll/value.rs
+++ b/src/ll/value.rs
@@ -21,7 +21,7 @@ pub use lists::*;
 pub use structs::*;
 pub use traits::*;
 
-use super::bytecode::Environment;
+use super::bytecode::Library;
 use crate::ll::{bytecode::DispatchTable, error::LanguageErrorKind, gc::GcRaw};
 
 /// The kind of a [`RawValue`].
@@ -402,15 +402,15 @@ pub trait UserData: Any + fmt::Debug {
     ///
     /// If the value requires the environment but it's not provided. This only happens with certain
     /// built-in types that are implemented as user data under the hood.
-    fn dtable_gcraw(&self, env: Option<&Environment>) -> GcRaw<DispatchTable>;
+    fn dtable_gcraw(&self, library: Option<&Library>) -> GcRaw<DispatchTable>;
 
     /// Returns the user data's dispatch table.
     ///
     /// # Safety
     /// This is basically sugar for `dtable_gcraw().get()`, so all the footguns of [`GcRaw::get`]
     /// apply.
-    unsafe fn dtable(&self, env: Option<&Environment>) -> &DispatchTable {
-        self.dtable_gcraw(env).get()
+    unsafe fn dtable(&self, library: Option<&Library>) -> &DispatchTable {
+        self.dtable_gcraw(library).get()
     }
 
     /// This is overridden by built-in types that need magical treatment (lists, dicts.)

--- a/src/ll/value/dicts.rs
+++ b/src/ll/value/dicts.rs
@@ -14,7 +14,7 @@ use hashbrown::raw::RawTable;
 use super::{RawValue, UserData, ValueKind};
 use crate::{
     ll::{
-        bytecode::{DispatchTable, Environment},
+        bytecode::{DispatchTable, Library},
         error::LanguageErrorKind,
         gc::GcRaw,
     },
@@ -154,9 +154,10 @@ impl fmt::Debug for Dict {
 }
 
 impl UserData for Dict {
-    fn dtable_gcraw(&self, env: Option<&Environment>) -> GcRaw<DispatchTable> {
+    fn dtable_gcraw(&self, library: Option<&Library>) -> GcRaw<DispatchTable> {
         Gc::as_raw(
-            &env.expect("UserData::dtable_gcraw called on a Dict with no environment")
+            &library
+                .expect("UserData::dtable_gcraw called on a Dict with no library")
                 .builtin_dtables
                 .dict,
         )

--- a/src/ll/value/lists.rs
+++ b/src/ll/value/lists.rs
@@ -9,7 +9,7 @@ use std::{
 use super::{RawValue, UserData};
 use crate::{
     ll::{
-        bytecode::{DispatchTable, Environment},
+        bytecode::{DispatchTable, Library},
         error::LanguageErrorKind,
         gc::GcRaw,
     },
@@ -87,9 +87,10 @@ impl fmt::Debug for List {
 }
 
 impl UserData for List {
-    fn dtable_gcraw(&self, env: Option<&Environment>) -> GcRaw<DispatchTable> {
+    fn dtable_gcraw(&self, library: Option<&Library>) -> GcRaw<DispatchTable> {
         Gc::as_raw(
-            &env.expect("UserData::dtable_gcraw called on List with no environment")
+            &library
+                .expect("UserData::dtable_gcraw called on List with no environment")
                 .builtin_dtables
                 .list,
         )

--- a/src/ll/vm.rs
+++ b/src/ll/vm.rs
@@ -2,7 +2,7 @@
 
 use std::{collections::HashSet, fmt, pin::Pin, ptr, rc::Rc};
 
-use super::bytecode::{FunctionIndex, GlobalIndex, ImplementedTraitIndex, MethodIndex};
+use super::bytecode::{FunctionIndex, GlobalIndex, ImplementedTraitIndex, Library, MethodIndex};
 use crate::ll::{
     bytecode::{
         CaptureKind, Chunk, Control, DispatchTable, Environment, FunctionKind,
@@ -198,15 +198,15 @@ impl Fiber {
     }
 
     /// Returns a reference to the `n`th value counted from the top of the stack.
-    fn nth_from_top(&self, n: usize) -> &RawValue {
+    fn nth_from_top(&self, n: usize) -> RawValue {
         #[cfg(debug_assertions)]
         {
-            &self.stack[self.stack.len() - n]
+            self.stack[self.stack.len() - n]
         }
         #[cfg(not(debug_assertions))]
         unsafe {
             let i = self.stack.len() - n;
-            self.stack.get_unchecked(i)
+            *self.stack.get_unchecked(i)
         }
     }
 
@@ -261,6 +261,7 @@ impl Fiber {
     fn enter_function(
         &mut self,
         env: &Environment,
+        library: &Library,
         globals: &mut Globals,
         gc: &mut Memory,
         closure: GcRaw<Closure>,
@@ -279,7 +280,7 @@ impl Fiber {
             FunctionKind::Foreign(f) => {
                 let arguments =
                     unsafe { self.stack.get_unchecked(self.stack.len() - argument_count..) };
-                let result = match f(env, gc, arguments) {
+                let result = match f(library, gc, arguments) {
                     Ok(value) => value,
                     Err(kind) => {
                         return Err(self.error_outside_function_call(Some(closure), env, kind));
@@ -375,17 +376,19 @@ impl Fiber {
     }
 
     /// Returns the dispatch table of the given value.
-    fn get_dispatch_table<'v>(value: &'v RawValue, env: &'v Environment) -> &'v DispatchTable {
+    fn get_dispatch_table(value: RawValue, library: &Library) -> &DispatchTable {
         unsafe {
             match value.kind() {
-                ValueKind::Nil => &env.builtin_dtables.nil,
-                ValueKind::Boolean => &env.builtin_dtables.boolean,
-                ValueKind::Number => &env.builtin_dtables.number,
-                ValueKind::String => &env.builtin_dtables.string,
-                ValueKind::Function => &env.builtin_dtables.function,
+                ValueKind::Nil => &library.builtin_dtables.nil,
+                ValueKind::Boolean => &library.builtin_dtables.boolean,
+                ValueKind::Number => &library.builtin_dtables.number,
+                ValueKind::String => &library.builtin_dtables.string,
+                ValueKind::Function => &library.builtin_dtables.function,
                 ValueKind::Struct => value.get_raw_struct_unchecked().get().dtable(),
                 ValueKind::Trait => value.get_raw_trait_unchecked().get().dtable(),
-                ValueKind::UserData => value.get_raw_user_data_unchecked().get().dtable(Some(env)),
+                ValueKind::UserData => {
+                    value.get_raw_user_data_unchecked().get().dtable(Some(library))
+                }
             }
         }
     }
@@ -478,6 +481,7 @@ impl Fiber {
     pub fn interpret(
         &mut self,
         env: &Environment,
+        library: &Library,
         globals: &mut Globals,
         gc: &mut Memory,
     ) -> Result<RawValue, LanguageError> {
@@ -716,13 +720,13 @@ impl Fiber {
                     let argument_count = usize::from(operand) + 1;
                     let function = self.nth_from_top(argument_count);
                     let closure = wrap_error!(function.ensure_raw_function());
-                    self.enter_function(env, globals, gc, closure, argument_count)?;
+                    self.enter_function(env, library, globals, gc, closure, argument_count)?;
                 }
                 Opcode::CallMethod => {
                     let (method_index, argument_count) = operand.unpack();
                     let method_index = MethodIndex::from_u16(method_index);
                     let receiver = self.nth_from_top(argument_count as usize);
-                    let dtable = Self::get_dispatch_table(receiver, env);
+                    let dtable = Self::get_dispatch_table(receiver, library);
                     #[cfg(feature = "trace-vm-calls")]
                     {
                         println!(
@@ -733,7 +737,14 @@ impl Fiber {
                         );
                     }
                     if let Some(closure) = dtable.get_method(method_index) {
-                        self.enter_function(env, globals, gc, closure, argument_count as usize)?;
+                        self.enter_function(
+                            env,
+                            library,
+                            globals,
+                            gc,
+                            closure,
+                            argument_count as usize,
+                        )?;
                     } else {
                         let signature = env
                             .get_method_signature(method_index)

--- a/xtask/src/codegen/function_variants.rs
+++ b/xtask/src/codegen/function_variants.rs
@@ -76,7 +76,7 @@ fn generate_for_params(
         user_generic_params: &[("Ret")],
         user_generic_bounds: &[BOUND_RET],
         map_result_action: r#"
-            Ok(result.into_value_with_environment(env).to_raw(gc))
+            Ok(result.into_value_with_library(library).to_raw(gc))
         "#,
         self_mode: SelfMode::Disabled,
     };
@@ -90,7 +90,7 @@ fn generate_for_params(
         user_generic_params: &["Ret", "Err"],
         user_generic_bounds: &[BOUND_RET, BOUND_ERR],
         map_result_action: r#"
-            wrap_in_language_error(result.map(|v| v.into_value_with_environment(env).to_raw(gc)))
+            wrap_in_language_error(result.map(|v| v.into_value_with_library(library).to_raw(gc)))
         "#,
         self_mode: SelfMode::Disabled,
     };
@@ -248,7 +248,7 @@ fn generate_variant(
     );
 
     let mut into_raw_foreign_function =
-        String::from(r#" let arguments = Arguments::new(args, env); "#);
+        String::from(r#" let arguments = Arguments::new(args, library); "#);
 
     if let SelfMode::Enabled { setup_code } = &self_mode {
         into_raw_foreign_function.push_str(setup_code);
@@ -297,7 +297,7 @@ fn generate_variant(
                 {parameter_count_definition}
 
                 fn into_raw_foreign_function(self) -> RawForeignFunction {{
-                    Box::new(move |env, gc, args| {{
+                    Box::new(move |library, gc, args| {{
                         {into_raw_foreign_function}
                     }})
                 }}


### PR DESCRIPTION
Closes #140.

Introduces a `Library` that contains information about all dispatch tables (builtin and user-defined) as well as builtin traits.