### PR TITLE
`_` pattern cleanup

### DIFF
--- a/src/ll/ast.rs
+++ b/src/ll/ast.rs
@@ -226,8 +226,8 @@ pub enum NodeKind {
     /// An identifier. Must contain string data.
     Identifier,
 
-    /// The discard pattern `_`
-    DiscardPattern,
+    /// The `_` expression (discard pattern.)
+    Underscore,
 
     /// A parenthesized expression.
     Paren,

--- a/src/ll/codegen.rs
+++ b/src/ll/codegen.rs
@@ -89,7 +89,7 @@ impl<'e> CodeGenerator<'e> {
             NodeKind::String => self.generate_string(ast, node),
 
             NodeKind::Identifier => self.generate_variable(ast, node)?,
-            NodeKind::DiscardPattern => {
+            NodeKind::Underscore => {
                 return Err(ast.error(node, LanguageErrorKind::CannotAccessDiscardPattern))
             }
 

--- a/src/ll/codegen/assignment.rs
+++ b/src/ll/codegen/assignment.rs
@@ -46,14 +46,14 @@ impl<'e> CodeGenerator<'e> {
                 // Iterate through the fields in reverse, since going from the top of the stack
                 // that's the order we want to destructure our variables in.
                 for &field in fields.iter().rev() {
-                    if ast.kind(field) == NodeKind::Underscore {
-                        self.chunk.emit(Opcode::Discard);
-                    } else {
-                        self.generate_pattern_destructuring(ast, field, Expression::Discarded)?;
-                    }
+                    self.generate_pattern_destructuring(ast, field, Expression::Discarded)?;
                 }
             }
-            NodeKind::Underscore => {}
+            NodeKind::Underscore => {
+                if result == Expression::Discarded {
+                    self.chunk.emit(Opcode::Discard);
+                }
+            }
             NodeKind::Record => self.generate_record_destructuring(ast, node, result)?,
             _ => return Err(ast.error(node, LanguageErrorKind::InvalidPattern)),
         }

--- a/src/ll/codegen/assignment.rs
+++ b/src/ll/codegen/assignment.rs
@@ -46,14 +46,14 @@ impl<'e> CodeGenerator<'e> {
                 // Iterate through the fields in reverse, since going from the top of the stack
                 // that's the order we want to destructure our variables in.
                 for &field in fields.iter().rev() {
-                    if ast.kind(field) == NodeKind::DiscardPattern {
+                    if ast.kind(field) == NodeKind::Underscore {
                         self.chunk.emit(Opcode::Discard);
                     } else {
                         self.generate_pattern_destructuring(ast, field, Expression::Discarded)?;
                     }
                 }
             }
-            NodeKind::DiscardPattern => {}
+            NodeKind::Underscore => {}
             NodeKind::Record => self.generate_record_destructuring(ast, node, result)?,
             _ => return Err(ast.error(node, LanguageErrorKind::InvalidPattern)),
         }

--- a/src/ll/codegen/tuples.rs
+++ b/src/ll/codegen/tuples.rs
@@ -97,7 +97,7 @@ impl<'e> CodeGenerator<'e> {
             value: NodeId,
         ) -> Result<(), LanguageError> {
             let pattern = if value == NodeId::EMPTY { key } else { value };
-            if ast.kind(pattern) == NodeKind::DiscardPattern {
+            if ast.kind(pattern) == NodeKind::Underscore {
                 generator.chunk.emit(Opcode::Discard);
                 Ok(())
             } else {

--- a/src/ll/parser.rs
+++ b/src/ll/parser.rs
@@ -559,7 +559,7 @@ impl Parser {
             TokenKind::String(_) => Ok(self.parse_string(token)),
             TokenKind::LongString(_) => self.parse_long_string(token),
             TokenKind::Identifier(_) => self.parse_identifier(token),
-            TokenKind::Underscore => Ok(self.parse_unit(token, NodeKind::DiscardPattern)),
+            TokenKind::Underscore => Ok(self.parse_unit(token, NodeKind::Underscore)),
 
             TokenKind::Minus => self.unary_operator(token, NodeKind::Negate),
             TokenKind::Bang => self.unary_operator(token, NodeKind::Not),

--- a/tests/language/variable/discard-declaration.test.mi
+++ b/tests/language/variable/discard-declaration.test.mi
@@ -1,3 +1,0 @@
-# Declare a discarded variable.
-
-let _ = "a string"

--- a/tests/language/variable/underscore/basic-usage.test.mi
+++ b/tests/language/variable/underscore/basic-usage.test.mi
@@ -1,0 +1,3 @@
+# Discard a value using the `_` pattern.
+
+let _ = "a string"

--- a/tests/language/variable/underscore/chaining.test.mi
+++ b/tests/language/variable/underscore/chaining.test.mi
@@ -1,0 +1,4 @@
+# `let _ = 1` is an expression itself and returns 1.
+
+let x = let _ = 1
+assert(x == 1)


### PR DESCRIPTION
Implementing what I meant in some of my comments in #150.

@grisenti - in particular, have a look at how `_` no longer needs to be a special case in tuple and record destructuring.